### PR TITLE
[feature] add --pattern option to filter based on component name

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Option|Default|Type|Description
 `--browser`|`chromium`|chromium, firefox, or webkit|Which browser to run the tests in
 `--build-dir`|`storybook-static`|string|Storybook static build directory
 `--headless`|`true`|boolean|Whether to run headlessly or not
-`--pattern`|`[\s\S]*`|regex string|Only run tests that match a component name pattern
+`--pattern`|`.*`|string regex|Only run tests that match a component name pattern
 `--timeout`|2000|number|Timeout (in milliseconds) for each test
 
 For example, to run non-headlessly on Firefox, you would run

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Option|Default|Type|Description
 `--browser`|`chromium`|chromium, firefox, or webkit|Which browser to run the tests in
 `--build-dir`|`storybook-static`|string|Storybook static build directory
 `--headless`|`true`|boolean|Whether to run headlessly or not
+`--pattern`|`[\s\S]*`|regex string|Only run tests that match a component name pattern
 `--timeout`|2000|number|Timeout (in milliseconds) for each test
 
 For example, to run non-headlessly on Firefox, you would run

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -47,7 +47,7 @@ function parse() {
     browser: getBrowser(argv.browser),
     iframePath: getIframePath(argv['build-dir']),
     headless: argv.headless,
-    pattern: argv.pattern,
+    pattern: new RegExp(argv.pattern),
     timeout: argv.timeout,
   };
 }

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -18,8 +18,14 @@ const options = {
   headless: {
     alias: 'h',
     default: true,
-    description: 'Wether the browser should be ran "headfully" (non-headlessly)',
+    description: 'Whether the browser should be ran "headfully" (non-headlessly)',
     type: 'boolean' as const,
+  },
+  pattern: {
+    alias: 'p',
+    default: /[\s\S]*/,
+    description: 'Filter by a component name regex pattern',
+    type: 'string' as const,
   },
   timeout: {
     alias: 't',
@@ -41,6 +47,7 @@ function parse() {
     browser: getBrowser(argv.browser),
     iframePath: getIframePath(argv['build-dir']),
     headless: argv.headless,
+    pattern: argv.pattern,
     timeout: argv.timeout,
   };
 }

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -23,7 +23,7 @@ const options = {
   },
   pattern: {
     alias: 'p',
-    default: /[\s\S]*/,
+    default: '.*',
     description: 'Filter by a component name regex pattern',
     type: 'string' as const,
   },

--- a/src/Suite.ts
+++ b/src/Suite.ts
@@ -15,7 +15,6 @@ async function writeTests() {
   const page = await TestBrowser.createPage(testBrowser, options);
   const stories = await TestBrowser.getStories(page);
   const storiesByComponent = groupBy(stories, 'componentTitle');
-  const patternRegex = new RegExp(options.pattern);
 
   describe(`[${options.browser}] accessibility`, function () {
     after(async function () {
@@ -23,11 +22,11 @@ async function writeTests() {
     });
 
     each(storiesByComponent, (stories, componentTitle) => {
-      const nameMatches = patternRegex.test(componentTitle);
+      const nameMatches = options.pattern.test(componentTitle);
       const describeFn = nameMatches ? describe : describe.skip;
-      const testName = nameMatches ? componentTitle : `[skipped] ${componentTitle}`;
+      const describeName = nameMatches ? componentTitle : `[skipped] ${componentTitle}`;
 
-      describeFn(testName, () => {
+      describeFn(describeName, () => {
         stories.forEach((story) => {
           const testFn = ProcessedStory.isEnabled(story) ? it : it.skip;
 

--- a/src/Suite.ts
+++ b/src/Suite.ts
@@ -15,6 +15,7 @@ async function writeTests() {
   const page = await TestBrowser.createPage(testBrowser, options);
   const stories = await TestBrowser.getStories(page);
   const storiesByComponent = groupBy(stories, 'componentTitle');
+  const patternRegex = new RegExp(options.pattern);
 
   describe(`[${options.browser}] accessibility`, function () {
     after(async function () {
@@ -22,10 +23,11 @@ async function writeTests() {
     });
 
     each(storiesByComponent, (stories, componentTitle) => {
-      if (!componentTitle.match(options.pattern)) {
-        return;
-      }
-      describe(componentTitle, () => {
+      const nameMatches = patternRegex.test(componentTitle);
+      const describeFn = nameMatches ? describe : describe.skip;
+      const testName = nameMatches ? componentTitle : `[skipped] ${componentTitle}`;
+
+      describeFn(testName, () => {
         stories.forEach((story) => {
           const testFn = ProcessedStory.isEnabled(story) ? it : it.skip;
 

--- a/src/Suite.ts
+++ b/src/Suite.ts
@@ -22,6 +22,9 @@ async function writeTests() {
     });
 
     each(storiesByComponent, (stories, componentTitle) => {
+      if (!componentTitle.match(options.pattern)) {
+        return;
+      }
       describe(componentTitle, () => {
         stories.forEach((story) => {
           const testFn = ProcessedStory.isEnabled(story) ? it : it.skip;


### PR DESCRIPTION
[ch task](https://app.clubhouse.io/connections/story/29079/add-cli-option-to-run-on-specific-components)

Adds CLI option to only run tests that match a given regex

Testing:
- Running `yarn:demo` without option runs all tests
- Running `yarn:demo --pattern button` only runs tests in `button.stories` and marks `input` tests as skipped
<img width="582" alt="Screen Shot 2020-10-26 at 12 56 21 PM" src="https://user-images.githubusercontent.com/15840841/97221827-acfb2d00-178a-11eb-871c-24371b30ae14.png">

- Running `yarn:demo --pattern 'button|input'` runs tests in `button.stories` and `input.stories`