### PR TITLE
Run Github actions on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
In addition to pushes. That way, we get a CI run when somebody forks and submits a PR. We will end up with some duplicate builds (for pushes and PRs), but I think that's fine.

Noticed that we didn't get a build for #5.

@anniehu4 can you take a look at this, please?