### PR TITLE
Add option to specify formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Option|Default|Type|Description
 -|-|-|-
 `--browser`|`chromium`|chromium, firefox, or webkit|Which browser to run the tests in
 `--build-dir`|`storybook-static`|string|Storybook static build directory
-`--format`|`spec`|string|Formats to display test data in. Right now the only option is "spec"
+`--format`|`spec`|string|Format to output test data in. Right now the only option is "spec"
 `--headless`|`true`|boolean|Whether to run headlessly or not
 `--pattern`|`.*`|string regex|Only run tests that match a component name pattern
 `--timeout`|2000|number|Timeout (in milliseconds) for each test

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Option|Default|Type|Description
 -|-|-|-
 `--browser`|`chromium`|chromium, firefox, or webkit|Which browser to run the tests in
 `--build-dir`|`storybook-static`|string|Storybook static build directory
+`--format`|`spec`|string|Formats to display test data in. Right now the only option is "spec"
 `--headless`|`true`|boolean|Whether to run headlessly or not
 `--pattern`|`.*`|string regex|Only run tests that match a component name pattern
 `--timeout`|2000|number|Timeout (in milliseconds) for each test

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -15,6 +15,12 @@ const options = {
     description: 'Directory to load the static storybook built by build-storybook from',
     type: 'string' as const,
   },
+  format: {
+    alias: 'f',
+    default: 'spec',
+    description: 'The format to display the test run in',
+    type: 'string' as const,
+  },
   headless: {
     alias: 'h',
     default: true,
@@ -45,8 +51,9 @@ export function parseOptions() {
 
   return {
     browser: getBrowser(argv.browser),
-    iframePath: getIframePath(argv['build-dir']),
+    format: getFormat(argv.format),
     headless: argv.headless,
+    iframePath: getIframePath(argv['build-dir']),
     pattern: new RegExp(argv.pattern),
     timeout: argv.timeout,
   };
@@ -72,4 +79,13 @@ function getIframePath(buildDir: string) {
   }
 
   return iframePath;
+}
+
+function getFormat(format: string) {
+  switch (format) {
+    case 'spec':
+      return format;
+    default:
+      throw new Error(`Invalid format option: "${format}"`);
+  }
 }

--- a/src/formats/findFormat.ts
+++ b/src/formats/findFormat.ts
@@ -1,0 +1,12 @@
+import type { Options } from '../Options';
+import { SuiteEmitter } from '../Suite';
+import * as SpecFormat from './Spec';
+
+type Formatter = (emitter: SuiteEmitter) => void;
+
+export default function findFormat(options: Options): Formatter {
+  switch (options.format) {
+    case 'spec':
+      return SpecFormat.format;
+  }
+}

--- a/src/formats/index.js
+++ b/src/formats/index.js
@@ -1,0 +1,1 @@
+export { default as findFormat } from './findFormat';

--- a/src/formats/index.js
+++ b/src/formats/index.js
@@ -1,1 +1,0 @@
-export { default as findFormat } from './findFormat';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { parseOptions } from './Options';
 import * as Suite from './Suite';
-import * as SpecFormat from './formats/Spec';
+import { findFormat } from './formats';
 
 /**
  * Run the accessibility tests and return a promise that is resolved or rejected based on whether
@@ -9,12 +9,13 @@ import * as SpecFormat from './formats/Spec';
 export function run(): Promise<void> {
   return new Promise((resolve, reject) => {
     const options = parseOptions();
+    const format = findFormat(options);
     const emitter = Suite.run(options);
 
     emitter.on('suiteFinish', (_browser, _numPass, numFail) => {
       return numFail > 0 ? reject() : resolve();
     });
 
-    SpecFormat.format(emitter);
+    format(emitter);
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { parseOptions } from './Options';
 import * as Suite from './Suite';
-import { findFormat } from './formats';
+import findFormat from './formats/findFormat';
 
 /**
  * Run the accessibility tests and return a promise that is resolved or rejected based on whether


### PR DESCRIPTION
This PR adds a `--format` option. Right now there is only the "spec" option.

@anniehu4 can you take a look at this, please?

Also cc @eoinobrien. This probably affects the SARIF formatting, as well. Let me know if you have thoughts/feedback. 