### PR TITLE
axe-core peer dependency [breaking change]

### DIFF
--- a/demo/src/stories/input.stories.jsx
+++ b/demo/src/stories/input.stories.jsx
@@ -17,10 +17,10 @@ export const Input1 = () => (
 );
 Input1.storyName = 'Input with label (should pass)';
 
-export const Input2 = () => <Input placeholder="Favorite coffee" />;
+export const Input2 = () => <Input />;
 Input2.storyName = 'Input without label (should fail)';
 
-export const Input3 = () => <Input placeholder="Favorite coffee" />;
+export const Input3 = () => <Input />;
 Input3.storyName = 'Input without label but skipped (should pass)';
 Input3.parameters = {
   axe: {
@@ -28,10 +28,10 @@ Input3.parameters = {
   },
 };
 
-export const Input4 = () => <Input placeholder="Favorite coffee" role="wut-the-wut" />;
+export const Input4 = () => <Input role="wut-the-wut" />;
 Input4.storyName = 'Input without label and invalid role (should fail)';
 
-export const Input5 = () => <Input placeholder="Favorite coffee" />;
+export const Input5 = () => <Input />;
 Input5.storyName = 'Input without label but "label" rule is disabled (should pass)';
 Input5.parameters = {
   axe: {

--- a/package.json
+++ b/package.json
@@ -38,13 +38,15 @@
     "types": "tsc --noEmit"
   },
   "dependencies": {
-    "axe-core": "^4.0.2",
     "chalk": "^4.1.0",
     "indent-string": "^4.0.0",
     "lodash": "^4.17.20",
     "p-timeout": "^3.2.0",
     "playwright": "^1.4.2",
     "yargs": "^16.0.3"
+  },
+  "peerDependencies": {
+    "axe-core": "^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.11.6",
@@ -58,6 +60,7 @@
     "@types/node": "^14.11.8",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",
+    "axe-core": "^4.1.0",
     "babel-jest": "^26.3.0",
     "eslint": "^7.11.0",
     "eslint-plugin-import": "^2.22.0",

--- a/tests/integration/__snapshots__/integration.test.ts.snap
+++ b/tests/integration/__snapshots__/integration.test.ts.snap
@@ -29,7 +29,7 @@ exports[`can filter the components to run 1`] = `
 
        1. button-name (Buttons must have discernible text)
 
-          For more info, visit https://dequeuniversity.com/rules/axe/4.0/button-name?application=axeAPI.
+          For more info, visit https://dequeuniversity.com/rules/axe/4.1/button-name?application=axeAPI.
 
           Check these nodes:
 
@@ -38,9 +38,8 @@ exports[`can filter the components to run 1`] = `
                        Element does not have inner text that is visible to screen readers
                        aria-label attribute does not exist or is empty
                        aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-                       Element's default semantics were not overridden with role=\\"presentation\\"
-                       Element's default semantics were not overridden with role=\\"none\\"
-                       Element has no title attribute or the title attribute is empty
+                       Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
+                       Element has no title attribute
 
 2) [chromium] accessibility
      button
@@ -50,7 +49,7 @@ exports[`can filter the components to run 1`] = `
 
        1. color-contrast (Elements must have sufficient color contrast)
 
-          For more info, visit https://dequeuniversity.com/rules/axe/4.0/color-contrast?application=axeAPI.
+          For more info, visit https://dequeuniversity.com/rules/axe/4.1/color-contrast?application=axeAPI.
 
           Check these nodes:
 
@@ -66,7 +65,7 @@ exports[`can filter the components to run 1`] = `
 
        1. color-contrast (Elements must have sufficient color contrast)
 
-          For more info, visit https://dequeuniversity.com/rules/axe/4.0/color-contrast?application=axeAPI.
+          For more info, visit https://dequeuniversity.com/rules/axe/4.1/color-contrast?application=axeAPI.
 
           Check these nodes:
 
@@ -116,7 +115,7 @@ exports[`outputs accessibility violation information for the demo app 1`] = `
 
        1. button-name (Buttons must have discernible text)
 
-          For more info, visit https://dequeuniversity.com/rules/axe/4.0/button-name?application=axeAPI.
+          For more info, visit https://dequeuniversity.com/rules/axe/4.1/button-name?application=axeAPI.
 
           Check these nodes:
 
@@ -125,9 +124,8 @@ exports[`outputs accessibility violation information for the demo app 1`] = `
                        Element does not have inner text that is visible to screen readers
                        aria-label attribute does not exist or is empty
                        aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-                       Element's default semantics were not overridden with role=\\"presentation\\"
-                       Element's default semantics were not overridden with role=\\"none\\"
-                       Element has no title attribute or the title attribute is empty
+                       Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
+                       Element has no title attribute
 
 2) [chromium] accessibility
      button
@@ -137,7 +135,7 @@ exports[`outputs accessibility violation information for the demo app 1`] = `
 
        1. color-contrast (Elements must have sufficient color contrast)
 
-          For more info, visit https://dequeuniversity.com/rules/axe/4.0/color-contrast?application=axeAPI.
+          For more info, visit https://dequeuniversity.com/rules/axe/4.1/color-contrast?application=axeAPI.
 
           Check these nodes:
 
@@ -153,7 +151,7 @@ exports[`outputs accessibility violation information for the demo app 1`] = `
 
        1. color-contrast (Elements must have sufficient color contrast)
 
-          For more info, visit https://dequeuniversity.com/rules/axe/4.0/color-contrast?application=axeAPI.
+          For more info, visit https://dequeuniversity.com/rules/axe/4.1/color-contrast?application=axeAPI.
 
           Check these nodes:
 
@@ -173,19 +171,19 @@ exports[`outputs accessibility violation information for the demo app 1`] = `
 
        1. label (Form elements must have labels)
 
-          For more info, visit https://dequeuniversity.com/rules/axe/4.0/label?application=axeAPI.
+          For more info, visit https://dequeuniversity.com/rules/axe/4.1/label?application=axeAPI.
 
           Check these nodes:
 
-          - html: <input placeholder=\\"Favorite coffee\\">
+          - html: <input>
             summary: Fix any of the following:
                        aria-label attribute does not exist or is empty
                        aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
                        Form element does not have an implicit (wrapped) <label>
                        Form element does not have an explicit <label>
-                       Element has no title attribute or the title attribute is empty
-                       Element's default semantics were not overridden with role=\\"none\\"
-                       Element's default semantics were not overridden with role=\\"presentation\\"
+                       Element has no title attribute
+                       Element has no placeholder attribute
+                       Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
 5) [chromium] accessibility
      input
@@ -195,29 +193,29 @@ exports[`outputs accessibility violation information for the demo app 1`] = `
 
        1. aria-roles (ARIA roles used must conform to valid values)
 
-          For more info, visit https://dequeuniversity.com/rules/axe/4.0/aria-roles?application=axeAPI.
+          For more info, visit https://dequeuniversity.com/rules/axe/4.1/aria-roles?application=axeAPI.
 
           Check these nodes:
 
-          - html: <input placeholder=\\"Favorite coffee\\" role=\\"wut-the-wut\\">
+          - html: <input role=\\"wut-the-wut\\">
             summary: Fix all of the following:
                        Role must be one of the valid ARIA roles: wut-the-wut
 
        2. label (Form elements must have labels)
 
-          For more info, visit https://dequeuniversity.com/rules/axe/4.0/label?application=axeAPI.
+          For more info, visit https://dequeuniversity.com/rules/axe/4.1/label?application=axeAPI.
 
           Check these nodes:
 
-          - html: <input placeholder=\\"Favorite coffee\\" role=\\"wut-the-wut\\">
+          - html: <input role=\\"wut-the-wut\\">
             summary: Fix any of the following:
                        aria-label attribute does not exist or is empty
                        aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
                        Form element does not have an implicit (wrapped) <label>
                        Form element does not have an explicit <label>
-                       Element has no title attribute or the title attribute is empty
-                       Element's default semantics were not overridden with role=\\"none\\"
-                       Element's default semantics were not overridden with role=\\"presentation\\"
+                       Element has no title attribute
+                       Element has no placeholder attribute
+                       Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
 "

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,10 +1935,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
-axe-core@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.0.2.tgz#c7cf7378378a51fcd272d3c09668002a4990b1cb"
-  integrity sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==
+axe-core@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.0.tgz#93d395e6262ecdde5cb52a5d06533d0a0c7bb4cd"
+  integrity sha512-9atDIOTDLsWL+1GbBec6omflaT5Cxh88J0GtJtGfCVIXpI02rXHkju59W5mMqWa7eiC5OR168v3TK3kUKBW98g==
 
 babel-jest@^26.3.0, babel-jest@^26.5.2:
   version "26.5.2"


### PR DESCRIPTION
This PR makes axe-core a peer dependency, so that apps using it can use whatever version of axe-core they want (>= 4.0.0). Doing so will mean people can upgrade axe-core without waiting on a new release from this project.