### PR TITLE
Handle errors during browser launching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [fix] Handle errors during browser initialization - [#22](https://github.com/chanzuckerberg/axe-storybook-testing/pull/22)
 - [maintenance] Refactor browser functionality into a single class - [#13](https://github.com/chanzuckerberg/axe-storybook-testing/pull/13)
 - [maintenance] Group suite files into a suite/ directory - [#19](https://github.com/chanzuckerberg/axe-storybook-testing/pull/19)
 

--- a/src/browser/TestBrowser.ts
+++ b/src/browser/TestBrowser.ts
@@ -24,14 +24,22 @@ export default class TestBrowser {
       ],
     });
 
-    const context = await browser.newContext({ bypassCSP: true });
+    try {
+      const context = await browser.newContext({ bypassCSP: true });
 
-    // Create a new page at Storybook's static iframe and with axe-core setup and ready to run.
-    const page = await context.newPage();
-    await page.goto('file://' + options.iframePath);
-    await AxePage.prepare(page);
+      // Create a new page at Storybook's static iframe and with axe-core setup and ready to run.
+      const page = await context.newPage();
+      await page.goto('file://' + options.iframePath);
+      await AxePage.prepare(page);
 
-    return new TestBrowser(browser, page);
+      return new TestBrowser(browser, page);
+    } catch (message) {
+      // Something has gone wrong after the browser was launched. Make sure we clean up the opened
+      // browser.
+      await browser.close();
+      // Reject this promise.
+      throw message;
+    }
   }
 
   private constructor(browser: Browser, page: Page) {

--- a/src/formats/Spec.ts
+++ b/src/formats/Spec.ts
@@ -23,6 +23,15 @@ export function format(emitter: SuiteEmitter, print = console.log, colors = new 
     print(`[${browser}] accessibility`);
   });
 
+  emitter.on('suiteError', (error) => {
+    print(dedent`
+      ${colors.red('Error! The suite failed to run')}
+      An error was encountered before we started testing stories. Likely this means the browser failed to open.
+    `);
+    print('');
+    print(String(error));
+  });
+
   emitter.on('componentStart', (componentName) => {
     print(indent(componentName, 2));
   });

--- a/src/suite/Suite.ts
+++ b/src/suite/Suite.ts
@@ -13,6 +13,7 @@ import { createEmitter, Emitter } from './Emitter';
  */
 export type SuiteEvents = {
   suiteStart: (browser: string) => void;
+  suiteError: (error: Error) => void;
   componentStart: (componentName: string) => void;
   componentSkip: (componentName: string) => void;
   storyStart: (storyName: string, componentName: string) => void;
@@ -44,60 +45,70 @@ export function run(options: Options): SuiteEmitter {
     emitter.emit('suiteStart', options.browser);
 
     // Get the Storybook stories.
-    const browser = await Browser.create(options);
-    const stories = await browser.getStories();
-    const storiesByComponent = groupBy(stories, 'componentName');
-    const storiesAndComponents = Object.entries(storiesByComponent);
-
     try {
-      // Iterate each component.
-      for (const [componentName, stories] of storiesAndComponents) {
-        const shouldComponentRun = options.pattern.test(componentName);
+      const browser = await Browser.create(options);
+      const stories = await browser.getStories();
+      const storiesByComponent = groupBy(stories, 'componentName');
+      const storiesAndComponents = Object.entries(storiesByComponent);
 
-        if (shouldComponentRun) {
-          emitter.emit('componentStart', componentName);
-        } else {
-          emitter.emit('componentSkip', componentName);
-        }
+      try {
+        // Iterate each component.
+        for (const [componentName, stories] of storiesAndComponents) {
+          const shouldComponentRun = options.pattern.test(componentName);
 
-        // Iterate each story in this component.
-        for (const story of stories) {
-          const storyStartTime = Date.now();
-
-          if (!shouldComponentRun || !isEnabled(story)) {
-            numSkip += 1;
-            emitter.emit('storySkip', story.name, componentName);
-            continue;
+          if (shouldComponentRun) {
+            emitter.emit('componentStart', componentName);
+          } else {
+            emitter.emit('componentSkip', componentName);
           }
 
-          emitter.emit('storyStart', story.name, componentName);
+          // Iterate each story in this component.
+          for (const story of stories) {
+            const storyStartTime = Date.now();
 
-          try {
-            // Detect any Axe violations for this story.
-            const result = await pTimeout(browser.getResultForStory(story), options.timeout);
-            const storyEndTime = Date.now();
-            const storyElapsedTime = storyEndTime - storyStartTime;
-
-            if (isPassing(result, options.failingImpacts)) {
-              numPass += 1;
-              emitter.emit('storyPass', story.name, componentName, result, storyElapsedTime);
-            } else {
-              numFail += 1;
-              emitter.emit('storyFail', story.name, componentName, result, storyElapsedTime);
+            if (!shouldComponentRun || !isEnabled(story)) {
+              numSkip += 1;
+              emitter.emit('storySkip', story.name, componentName);
+              continue;
             }
-          } catch (message) {
-            numFail += 1;
-            const error = message instanceof Error ? message : new Error(message);
-            emitter.emit('storyError', story.name, componentName, error);
+
+            emitter.emit('storyStart', story.name, componentName);
+
+            try {
+              // Detect any Axe violations for this story.
+              const result = await pTimeout(browser.getResultForStory(story), options.timeout);
+              const storyEndTime = Date.now();
+              const storyElapsedTime = storyEndTime - storyStartTime;
+
+              if (isPassing(result, options.failingImpacts)) {
+                numPass += 1;
+                emitter.emit('storyPass', story.name, componentName, result, storyElapsedTime);
+              } else {
+                numFail += 1;
+                emitter.emit('storyFail', story.name, componentName, result, storyElapsedTime);
+              }
+            } catch (message) {
+              numFail += 1;
+              const error = message instanceof Error ? message : new Error(message);
+              emitter.emit('storyError', story.name, componentName, error);
+            }
           }
         }
-      }
 
-      const suiteEndTime = Date.now();
-      const suiteElapsedTime = suiteEndTime - suiteStartTime;
-      emitter.emit('suiteFinish', options.browser, numPass, numFail, numSkip, suiteElapsedTime);
-    } finally {
-      await browser.close();
+        const suiteEndTime = Date.now();
+        const suiteElapsedTime = suiteEndTime - suiteStartTime;
+        emitter.emit('suiteFinish', options.browser, numPass, numFail, numSkip, suiteElapsedTime);
+      } finally {
+        await browser.close();
+      }
+    } catch (message) {
+      // The test suite failed to run. Likely the browser failed to open, or something else went
+      // wrong before we started iterating components.
+      const error = message instanceof Error ? message : new Error(message);
+      emitter.emit('suiteError', error);
+      // Signal that the test suite is done. Pass a failed count of 1 to indicate that the test run
+      // was unsuccessful.
+      emitter.emit('suiteFinish', options.browser, 0, 1, 0, 0);
     }
   });
 


### PR DESCRIPTION
Handle errors during browser launching.

Noticed this in https://github.com/chanzuckerberg/along/runs/1750255462?check_suite_focus=true, where some CI workflow changes caused playwright to throw an error while opening the browser, but the accessibility job was still green.