### PR TITLE
Install ts-dedent as a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lodash": "^4.17.21",
     "p-timeout": "^4.1.0",
     "playwright": "^1.9.1",
+    "ts-dedent": "^2.1.1",
     "yargs": "^16.2.0"
   },
   "peerDependencies": {
@@ -73,7 +74,6 @@
     "react-dom": "^16.13.1",
     "rimraf": "^3.0.0",
     "start-server-and-test": "^1.12.0",
-    "ts-dedent": "^2.0.0",
     "typescript": "^4.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6062,6 +6062,11 @@ ts-dedent@^2.0.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.0.0.tgz#47c5eb23d9096f3237cc413bc82d387d36dbe690"
   integrity sha512-DfxKjSFQfw9+uf7N9Cy8Ebx9fv5fquK4hZ6SD3Rzr+1jKP6AVA6H8+B5457ZpUs0JKsGpGqIevbpZ9DMQJDp1A==
 
+ts-dedent@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.1.1.tgz#6dd56870bb5493895171334fa5d7e929107e5bbc"
+  integrity sha512-riHuwnzAUCfdIeTBNUq7+Yj+ANnrMXo/7+Z74dIdudS7ys2k8aSGMzpJRMFDF7CLwUTbtvi1ZZff/Wl+XxmqIA==
+
 tsconfig-paths@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"


### PR DESCRIPTION
[ts-dedent][0] was installed as a development-only dependency but is [used in the published code][1], leading to an error like `Error: Cannot find module 'ts-dedent'`.

This fixes that by moving `ts-dedent` from `devDependencies` to `dependencies`. It also upgrades it to the latest version, from v2.0.0 to v2.1.1.

[0]: https://www.npmjs.com/package/ts-dedent
[1]: https://github.com/chanzuckerberg/axe-storybook-testing/blob/6b4ceaae25332903157b8badd6f67facac917b10/src/formats/Spec.ts#L4