### PR TITLE
Wait for selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [new] Add `waitForSelector` story parameter [#35](https://github.com/chanzuckerberg/axe-storybook-testing/pull/35)
+
 ## 4.0.1 (2021-9-14)
 
 - [fix] Ensure `prefers-reduced-motion` is turned on [#33](https://github.com/chanzuckerberg/axe-storybook-testing/pull/33)

--- a/README.md
+++ b/README.md
@@ -130,6 +130,20 @@ export const parameters = {
 };
 ```
 
+### waitForSelector
+
+Wait for an arbitrary CSS selector after rendering before running the Axe checks. Useful if your component takes some time to render and actually display itself on the page.
+
+```jsx
+// SomeComponent.stories.jsx
+
+export const parameters = {
+  axe: {
+    waitForSelector: '#some-component-selector',
+  },
+};
+```
+
 ## Developing
 
 If you want to work on this project or contribute back to it, see our [wiki entry on Development setup](https://github.com/chanzuckerberg/axe-storybook-testing/wiki/Development-setup).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Stories can use parameters to configure how axe-storybook-testing handles them.
 Prevent axe-storybook-testing from running a story by using the `skip` parameter.
 
 ```jsx
-// SomeStory.stories.jsx
+// SomeComponent.stories.jsx
 
 SomeStory.parameters = {
   axe: {
@@ -109,7 +109,7 @@ SomeStory.parameters = {
 Prevent axe-storybook-testing from running specific Axe rules on a story by using the `disabledRules` parameter.
 
 ```jsx
-// SomeStory.stories.jsx
+// SomeComponent.stories.jsx
 
 SomeStory.parameters = {
   axe: {

--- a/demo/src/stories/delays.stories.jsx
+++ b/demo/src/stories/delays.stories.jsx
@@ -13,15 +13,15 @@ function NotDelayed() {
 // Render NotDelayed after a timeout. Should initially "pass" accessibility checks, since there is
 // nothing initially rendered. But if we either run them again (in Storybook) or delay the Axe check
 // (with `waitForSelector`) we should see the failure.
-function Delayed() {
+function Delayed({ delay }) {
   const [show, setShow] = React.useState(false);
 
   React.useEffect(() => {
     const timeoutId = setTimeout(() => {
       setShow(true);
-    }, 1000);
+    }, delay);
     return () => clearTimeout(timeoutId);
-  }, []);
+  }, [delay]);
 
   return show ? <NotDelayed /> : null;
 }
@@ -29,9 +29,17 @@ function Delayed() {
 export const NoDelay = () => <NotDelayed />;
 NoDelay.storyName = 'NoDelay (should fail)';
 
-export const Delay = () => <Delayed />;
-Delay.storyName = 'Delay (should fail)';
-Delay.parameters = {
+export const ShortDelay = () => <Delayed delay={500} />;
+ShortDelay.storyName = 'ShortDelay (should fail)';
+ShortDelay.parameters = {
+  axe: {
+    waitForSelector: '#the-tab',
+  },
+};
+
+export const LongDelay = () => <Delayed delay={30000} />;
+LongDelay.storyName = 'LongDelay (should fail with timeout)';
+LongDelay.parameters = {
   axe: {
     waitForSelector: '#the-tab',
   },

--- a/demo/src/stories/delays.stories.jsx
+++ b/demo/src/stories/delays.stories.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export default {
+  title: 'delays',
+  component: NotDelayed,
+};
+
+function NotDelayed() {
+  // axe violation since tab must be within a tablist.
+  return <button id="the-tab" role="tab">Tab</button>;
+}
+
+// Render NotDelayed after a timeout. Should initially "pass" accessibility checks, since there is
+// nothing initially rendered. But if we either run them again (in Storybook) or delay the Axe check
+// (with `waitForSelector`) we should see the failure.
+function Delayed() {
+  const [show, setShow] = React.useState(false);
+
+  React.useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setShow(true);
+    }, 1000);
+    return () => clearTimeout(timeoutId);
+  }, []);
+
+  return show ? <NotDelayed /> : null;
+}
+
+export const NoDelay = () => <NotDelayed />;
+NoDelay.storyName = 'NoDelay (should fail)';
+
+export const Delay = () => <Delayed />;
+Delay.storyName = 'Delay (should fail)';
+Delay.parameters = {
+  axe: {
+    waitForSelector: '#the-tab',
+  },
+};

--- a/src/ProcessedStory.ts
+++ b/src/ProcessedStory.ts
@@ -10,6 +10,7 @@ export type ProcessedStory = {
     axe: {
       skip: boolean;
       disabledRules: string[];
+      waitForSelector?: string;
     },
   };
   storybookId: string;
@@ -33,6 +34,7 @@ export function fromStory(rawStory: StorybookStory): ProcessedStory {
       axe: {
         skip: normalizeSkip(rawStory.parameters?.axe?.skip),
         disabledRules: normalizeDisabledRules(rawStory.parameters?.axe?.disabledRules),
+        waitForSelector: normalizeWaitForSelector(rawStory.parameters?.axe?.waitForSelector),
       },
     },
     storybookId: rawStory.id,
@@ -71,4 +73,14 @@ function normalizeDisabledRules(disabledRules?: unknown): string[] {
     throw new Error(`Given disabledRules option '${JSON.stringify(disabledRules)}' is invalid`);
   }
   return disabledRules.map(String);
+}
+
+function normalizeWaitForSelector(waitForSelector?: unknown): string | undefined {
+  if (!waitForSelector) {
+    return undefined;
+  }
+  if (typeof waitForSelector !== 'string') {
+    throw new Error(`Value of 'waitForSelector' option '${waitForSelector}' is invalid`);
+  }
+  return waitForSelector;
 }

--- a/src/browser/TestBrowser.ts
+++ b/src/browser/TestBrowser.ts
@@ -61,7 +61,13 @@ export default class TestBrowser {
    * Run Axe for a story.
    */
   async getResultForStory(story: ProcessedStory.ProcessedStory): Promise<Result.Result> {
+    const storyParams = story.parameters.axe;
     await StorybookPage.showStory(this.page, story);
+
+    if (storyParams.waitForSelector) {
+      await this.page.waitForSelector(storyParams.waitForSelector);
+    }
+
     return Result.fromPage(this.page, story);
   }
 

--- a/tests/integration/__snapshots__/integration.test.ts.snap
+++ b/tests/integration/__snapshots__/integration.test.ts.snap
@@ -12,16 +12,17 @@ exports[`failing specific impact levels 1`] = `
     ✓ Multiple buttons with insufficient color contrast (should fail)
   delays
     2) NoDelay (should fail)
-    3) Delay (should fail)
+    3) ShortDelay (should fail)
+    4) LongDelay (should fail with timeout)
   input
     ✓ Input with label (should pass)
-    4) Input without label (should fail)
+    5) Input without label (should fail)
     - Input without label but skipped (should pass)
-    5) Input without label and invalid role (should fail)
+    6) Input without label and invalid role (should fail)
     ✓ Input without label but \\"label\\" rule is disabled (should pass)
 
 6 passing
-5 failing
+6 failing
 2 pending
 
 1) [chromium] accessibility
@@ -62,7 +63,7 @@ exports[`failing specific impact levels 1`] = `
 
 3) [chromium] accessibility
      delays
-       Delay (should fail)
+       ShortDelay (should fail)
 
        Detected the following accessibility violations!
 
@@ -77,6 +78,12 @@ exports[`failing specific impact levels 1`] = `
                        Required ARIA parent role not present: tablist
 
 4) [chromium] accessibility
+     delays
+       LongDelay (should fail with timeout)
+
+       TimeoutError: Promise timed out after 2000 milliseconds
+
+5) [chromium] accessibility
      input
        Input without label (should fail)
 
@@ -98,7 +105,7 @@ exports[`failing specific impact levels 1`] = `
                        Element has no placeholder attribute
                        Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
-5) [chromium] accessibility
+6) [chromium] accessibility
      input
        Input without label and invalid role (should fail)
 
@@ -151,7 +158,8 @@ exports[`filtering the components to run 1`] = `
     3) Multiple buttons with insufficient color contrast (should fail)
   [skipped] delays
     - NoDelay (should fail)
-    - Delay (should fail)
+    - ShortDelay (should fail)
+    - LongDelay (should fail with timeout)
   [skipped] input
     - Input with label (should pass)
     - Input without label (should fail)
@@ -161,7 +169,7 @@ exports[`filtering the components to run 1`] = `
 
 2 passing
 3 failing
-8 pending
+9 pending
 
 1) [chromium] accessibility
      button
@@ -240,16 +248,17 @@ exports[`outputting accessibility violation information for the demo app 1`] = `
     3) Multiple buttons with insufficient color contrast (should fail)
   delays
     4) NoDelay (should fail)
-    5) Delay (should fail)
+    5) ShortDelay (should fail)
+    6) LongDelay (should fail with timeout)
   input
     ✓ Input with label (should pass)
-    6) Input without label (should fail)
+    7) Input without label (should fail)
     - Input without label but skipped (should pass)
-    7) Input without label and invalid role (should fail)
+    8) Input without label and invalid role (should fail)
     ✓ Input without label but \\"label\\" rule is disabled (should pass)
 
 4 passing
-7 failing
+8 failing
 2 pending
 
 1) [chromium] accessibility
@@ -326,7 +335,7 @@ exports[`outputting accessibility violation information for the demo app 1`] = `
 
 5) [chromium] accessibility
      delays
-       Delay (should fail)
+       ShortDelay (should fail)
 
        Detected the following accessibility violations!
 
@@ -341,6 +350,12 @@ exports[`outputting accessibility violation information for the demo app 1`] = `
                        Required ARIA parent role not present: tablist
 
 6) [chromium] accessibility
+     delays
+       LongDelay (should fail with timeout)
+
+       TimeoutError: Promise timed out after 2000 milliseconds
+
+7) [chromium] accessibility
      input
        Input without label (should fail)
 
@@ -362,7 +377,7 @@ exports[`outputting accessibility violation information for the demo app 1`] = `
                        Element has no placeholder attribute
                        Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
-7) [chromium] accessibility
+8) [chromium] accessibility
      input
        Input without label and invalid role (should fail)
 

--- a/tests/integration/__snapshots__/integration.test.ts.snap
+++ b/tests/integration/__snapshots__/integration.test.ts.snap
@@ -10,15 +10,18 @@ exports[`failing specific impact levels 1`] = `
     ✓ Button with insufficient color contrast (should fail)
     - Button with insufficient color contrast but skipped (should pass)
     ✓ Multiple buttons with insufficient color contrast (should fail)
+  delays
+    2) NoDelay (should fail)
+    3) Delay (should fail)
   input
     ✓ Input with label (should pass)
-    2) Input without label (should fail)
+    4) Input without label (should fail)
     - Input without label but skipped (should pass)
-    3) Input without label and invalid role (should fail)
+    5) Input without label and invalid role (should fail)
     ✓ Input without label but \\"label\\" rule is disabled (should pass)
 
 6 passing
-3 failing
+5 failing
 2 pending
 
 1) [chromium] accessibility
@@ -42,6 +45,38 @@ exports[`failing specific impact levels 1`] = `
                        Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
 2) [chromium] accessibility
+     delays
+       NoDelay (should fail)
+
+       Detected the following accessibility violations!
+
+       1. aria-required-parent (Certain ARIA roles must be contained by particular parents)
+
+          For more info, visit https://dequeuniversity.com/rules/axe/4.3/aria-required-parent?application=axeAPI.
+
+          Check these nodes:
+
+          - html: <button id=\\"the-tab\\" role=\\"tab\\">Tab</button>
+            summary: Fix any of the following:
+                       Required ARIA parent role not present: tablist
+
+3) [chromium] accessibility
+     delays
+       Delay (should fail)
+
+       Detected the following accessibility violations!
+
+       1. aria-required-parent (Certain ARIA roles must be contained by particular parents)
+
+          For more info, visit https://dequeuniversity.com/rules/axe/4.3/aria-required-parent?application=axeAPI.
+
+          Check these nodes:
+
+          - html: <button id=\\"the-tab\\" role=\\"tab\\">Tab</button>
+            summary: Fix any of the following:
+                       Required ARIA parent role not present: tablist
+
+4) [chromium] accessibility
      input
        Input without label (should fail)
 
@@ -63,7 +98,7 @@ exports[`failing specific impact levels 1`] = `
                        Element has no placeholder attribute
                        Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
-3) [chromium] accessibility
+5) [chromium] accessibility
      input
        Input without label and invalid role (should fail)
 
@@ -114,6 +149,9 @@ exports[`filtering the components to run 1`] = `
     2) Button with insufficient color contrast (should fail)
     - Button with insufficient color contrast but skipped (should pass)
     3) Multiple buttons with insufficient color contrast (should fail)
+  [skipped] delays
+    - NoDelay (should fail)
+    - Delay (should fail)
   [skipped] input
     - Input with label (should pass)
     - Input without label (should fail)
@@ -123,7 +161,7 @@ exports[`filtering the components to run 1`] = `
 
 2 passing
 3 failing
-6 pending
+8 pending
 
 1) [chromium] accessibility
      button
@@ -200,15 +238,18 @@ exports[`outputting accessibility violation information for the demo app 1`] = `
     2) Button with insufficient color contrast (should fail)
     - Button with insufficient color contrast but skipped (should pass)
     3) Multiple buttons with insufficient color contrast (should fail)
+  delays
+    4) NoDelay (should fail)
+    5) Delay (should fail)
   input
     ✓ Input with label (should pass)
-    4) Input without label (should fail)
+    6) Input without label (should fail)
     - Input without label but skipped (should pass)
-    5) Input without label and invalid role (should fail)
+    7) Input without label and invalid role (should fail)
     ✓ Input without label but \\"label\\" rule is disabled (should pass)
 
 4 passing
-5 failing
+7 failing
 2 pending
 
 1) [chromium] accessibility
@@ -268,6 +309,38 @@ exports[`outputting accessibility violation information for the demo app 1`] = `
                        Element has insufficient color contrast of 1.24 (foreground color: #32cd32, background color: #ff69b4, font size: 10.0pt (13.3333px), font weight: normal). Expected contrast ratio of 4.5:1
 
 4) [chromium] accessibility
+     delays
+       NoDelay (should fail)
+
+       Detected the following accessibility violations!
+
+       1. aria-required-parent (Certain ARIA roles must be contained by particular parents)
+
+          For more info, visit https://dequeuniversity.com/rules/axe/4.3/aria-required-parent?application=axeAPI.
+
+          Check these nodes:
+
+          - html: <button id=\\"the-tab\\" role=\\"tab\\">Tab</button>
+            summary: Fix any of the following:
+                       Required ARIA parent role not present: tablist
+
+5) [chromium] accessibility
+     delays
+       Delay (should fail)
+
+       Detected the following accessibility violations!
+
+       1. aria-required-parent (Certain ARIA roles must be contained by particular parents)
+
+          For more info, visit https://dequeuniversity.com/rules/axe/4.3/aria-required-parent?application=axeAPI.
+
+          Check these nodes:
+
+          - html: <button id=\\"the-tab\\" role=\\"tab\\">Tab</button>
+            summary: Fix any of the following:
+                       Required ARIA parent role not present: tablist
+
+6) [chromium] accessibility
      input
        Input without label (should fail)
 
@@ -289,7 +362,7 @@ exports[`outputting accessibility violation information for the demo app 1`] = `
                        Element has no placeholder attribute
                        Element's default semantics were not overridden with role=\\"none\\" or role=\\"presentation\\"
 
-5) [chromium] accessibility
+7) [chromium] accessibility
      input
        Input without label and invalid role (should fail)
 

--- a/tests/unit/ProcessedStory.test.ts
+++ b/tests/unit/ProcessedStory.test.ts
@@ -56,6 +56,7 @@ describe('fromStory', () => {
           axe: {
             skip: true,
             disabledRules: ['label'],
+            waitForSelector: '.foo',
           },
         },
       };
@@ -66,6 +67,7 @@ describe('fromStory', () => {
         axe: {
           skip: true,
           disabledRules: ['label'],
+          waitForSelector: '.foo',
         },
       });
     });


### PR DESCRIPTION
Hopefully this resolves https://github.com/chanzuckerberg/axe-storybook-testing/issues/34. It adds the `waitForSelector` parameter for stories. That way stories can wait for specific selectors to be visible on the page, if necessary.