### PR TITLE
Use Zod to parse story parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [maintenance] Use [Zod](https://github.com/colinhacks/zod) to validate story parameters, instead of custom logic [#37](https://github.com/chanzuckerberg/axe-storybook-testing/pull/37)
+
 ## 4.1.0 (2021-9-20)
 
 - [new] Add `waitForSelector` story parameter [#35](https://github.com/chanzuckerberg/axe-storybook-testing/pull/35)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "p-timeout": "^4.1.0",
     "playwright": "^1.14.1",
     "ts-dedent": "^2.2.0",
-    "yargs": "^17.1.1"
+    "yargs": "^17.1.1",
+    "zod": "^3.8.2"
   },
   "peerDependencies": {
     "axe-core": "^4.0.0"

--- a/src/Parameters.ts
+++ b/src/Parameters.ts
@@ -1,38 +1,19 @@
 import { z as zod } from 'zod';
 
+export const ParamError = zod.ZodError;
+
 const skipSchema = zod.optional(zod.boolean());
 const disabledRulesSchema = zod.optional(zod.array(zod.string()));
 const waitForSelectorSchema = zod.optional(zod.string());
 
-export function parseSkip(skipped: unknown | undefined, errorMessage: string): zod.infer<typeof skipSchema> {
-  return parseWithFriendlyError(
-    () => skipSchema.parse(skipped),
-    errorMessage,
-  );
+export function parseSkip(skipped?: unknown): zod.infer<typeof skipSchema> {
+  return skipSchema.parse(skipped);
 }
 
-export function parseDisabledRules(disabledRules: unknown | undefined, errorMessage: string): zod.infer<typeof disabledRulesSchema> {
-  return parseWithFriendlyError(
-    () => disabledRulesSchema.parse(disabledRules),
-    errorMessage,
-  );
+export function parseDisabledRules(disabledRules?: unknown): zod.infer<typeof disabledRulesSchema> {
+  return disabledRulesSchema.parse(disabledRules);
 }
 
-export function parseWaitForSelector(waitForSelector: unknown | undefined, errorMessage: string): zod.infer<typeof waitForSelectorSchema> {
-  return parseWithFriendlyError(
-    () => waitForSelectorSchema.parse(waitForSelector),
-    errorMessage,
-  );
-}
-
-function parseWithFriendlyError<T>(parser: () => T, errorMessage: string): T {
-  try {
-    return parser();
-  } catch (message) {
-    if (message instanceof zod.ZodError) {
-      throw new TypeError(errorMessage);
-    } else {
-      throw message;
-    }
-  }
+export function parseWaitForSelector(waitForSelector?: unknown): zod.infer<typeof waitForSelectorSchema> {
+  return waitForSelectorSchema.parse(waitForSelector);
 }

--- a/src/Parameters.ts
+++ b/src/Parameters.ts
@@ -2,16 +2,16 @@ import { z as zod } from 'zod';
 
 export const ParamError = zod.ZodError;
 
-const skipSchema = zod.optional(zod.boolean());
-const disabledRulesSchema = zod.optional(zod.array(zod.string()));
+const skipSchema = zod.boolean();
+const disabledRulesSchema = zod.array(zod.string());
 const waitForSelectorSchema = zod.optional(zod.string());
 
 export function parseSkip(skipped: unknown): zod.infer<typeof skipSchema> {
-  return skipSchema.parse(skipped);
+  return skipSchema.optional().parse(skipped) || false;
 }
 
 export function parseDisabledRules(disabledRules: unknown): zod.infer<typeof disabledRulesSchema> {
-  return disabledRulesSchema.parse(disabledRules);
+  return disabledRulesSchema.optional().parse(disabledRules) || [];
 }
 
 export function parseWaitForSelector(waitForSelector: unknown): zod.infer<typeof waitForSelectorSchema> {

--- a/src/Parameters.ts
+++ b/src/Parameters.ts
@@ -1,5 +1,7 @@
 import { z as zod } from 'zod';
 
+// Functions for validating parameters and providing default values.
+
 export const ParamError = zod.ZodError;
 
 const skipSchema = zod.boolean();

--- a/src/Parameters.ts
+++ b/src/Parameters.ts
@@ -6,14 +6,14 @@ const skipSchema = zod.optional(zod.boolean());
 const disabledRulesSchema = zod.optional(zod.array(zod.string()));
 const waitForSelectorSchema = zod.optional(zod.string());
 
-export function parseSkip(skipped?: unknown): zod.infer<typeof skipSchema> {
+export function parseSkip(skipped: unknown): zod.infer<typeof skipSchema> {
   return skipSchema.parse(skipped);
 }
 
-export function parseDisabledRules(disabledRules?: unknown): zod.infer<typeof disabledRulesSchema> {
+export function parseDisabledRules(disabledRules: unknown): zod.infer<typeof disabledRulesSchema> {
   return disabledRulesSchema.parse(disabledRules);
 }
 
-export function parseWaitForSelector(waitForSelector?: unknown): zod.infer<typeof waitForSelectorSchema> {
+export function parseWaitForSelector(waitForSelector: unknown): zod.infer<typeof waitForSelectorSchema> {
   return waitForSelectorSchema.parse(waitForSelector);
 }

--- a/src/Parameters.ts
+++ b/src/Parameters.ts
@@ -1,0 +1,17 @@
+import { z as zod } from 'zod';
+
+const skipSchema = zod.optional(zod.boolean());
+const disabledRulesSchema = zod.optional(zod.array(zod.string()));
+const waitForSelectorSchema = zod.optional(zod.string());
+
+export function parseSkip(skipped?: unknown): zod.infer<typeof skipSchema> {
+  return skipSchema.parse(skipped);
+}
+
+export function parseDisabledRules(disabledRules?: unknown): zod.infer<typeof disabledRulesSchema> {
+  return disabledRulesSchema.parse(disabledRules);
+}
+
+export function parseWaitForSelector(waitForSelector?: unknown): zod.infer<typeof waitForSelectorSchema> {
+  return waitForSelectorSchema.parse(waitForSelector);
+}

--- a/src/Parameters.ts
+++ b/src/Parameters.ts
@@ -4,14 +4,35 @@ const skipSchema = zod.optional(zod.boolean());
 const disabledRulesSchema = zod.optional(zod.array(zod.string()));
 const waitForSelectorSchema = zod.optional(zod.string());
 
-export function parseSkip(skipped?: unknown): zod.infer<typeof skipSchema> {
-  return skipSchema.parse(skipped);
+export function parseSkip(skipped: unknown | undefined, errorMessage: string): zod.infer<typeof skipSchema> {
+  return parseWithFriendlyError(
+    () => skipSchema.parse(skipped),
+    errorMessage,
+  );
 }
 
-export function parseDisabledRules(disabledRules?: unknown): zod.infer<typeof disabledRulesSchema> {
-  return disabledRulesSchema.parse(disabledRules);
+export function parseDisabledRules(disabledRules: unknown | undefined, errorMessage: string): zod.infer<typeof disabledRulesSchema> {
+  return parseWithFriendlyError(
+    () => disabledRulesSchema.parse(disabledRules),
+    errorMessage,
+  );
 }
 
-export function parseWaitForSelector(waitForSelector?: unknown): zod.infer<typeof waitForSelectorSchema> {
-  return waitForSelectorSchema.parse(waitForSelector);
+export function parseWaitForSelector(waitForSelector: unknown | undefined, errorMessage: string): zod.infer<typeof waitForSelectorSchema> {
+  return parseWithFriendlyError(
+    () => waitForSelectorSchema.parse(waitForSelector),
+    errorMessage,
+  );
+}
+
+function parseWithFriendlyError<T>(parser: () => T, errorMessage: string): T {
+  try {
+    return parser();
+  } catch (message) {
+    if (message instanceof zod.ZodError) {
+      throw new TypeError(errorMessage);
+    } else {
+      throw message;
+    }
+  }
 }

--- a/src/ProcessedStory.ts
+++ b/src/ProcessedStory.ts
@@ -1,3 +1,4 @@
+import * as Parameters from './Parameters';
 import type { StorybookStory } from './browser/StorybookPage';
 
 /**
@@ -32,9 +33,9 @@ export function fromStory(rawStory: StorybookStory): ProcessedStory {
     name: rawStory.name,
     parameters: {
       axe: {
-        skip: normalizeSkip(rawStory.parameters?.axe?.skip),
-        disabledRules: normalizeDisabledRules(rawStory.parameters?.axe?.disabledRules),
-        waitForSelector: normalizeWaitForSelector(rawStory.parameters?.axe?.waitForSelector),
+        skip: Parameters.parseSkip(rawStory.parameters?.axe?.skip) || false,
+        disabledRules: Parameters.parseDisabledRules(rawStory.parameters?.axe?.disabledRules) || [],
+        waitForSelector: Parameters.parseWaitForSelector(rawStory.parameters?.axe?.waitForSelector),
       },
     },
     storybookId: rawStory.id,
@@ -53,34 +54,4 @@ export function isEnabled(story: ProcessedStory): boolean {
  */
 export function getDisabledRules(story: ProcessedStory): string[] {
   return story.parameters.axe.disabledRules;
-}
-
-function normalizeSkip(skipped?: unknown): boolean {
-  if (typeof skipped === 'undefined') {
-    return false;
-  }
-  if (typeof skipped !== 'boolean') {
-    throw new Error(`Value of 'skip' option '${skipped}' is invalid`);
-  }
-  return skipped;
-}
-
-function normalizeDisabledRules(disabledRules?: unknown): string[] {
-  if (typeof disabledRules === 'undefined') {
-    return [];
-  }
-  if (!Array.isArray(disabledRules)) {
-    throw new Error(`Given disabledRules option '${JSON.stringify(disabledRules)}' is invalid`);
-  }
-  return disabledRules.map(String);
-}
-
-function normalizeWaitForSelector(waitForSelector?: unknown): string | undefined {
-  if (!waitForSelector) {
-    return undefined;
-  }
-  if (typeof waitForSelector !== 'string') {
-    throw new Error(`Value of 'waitForSelector' option '${waitForSelector}' is invalid`);
-  }
-  return waitForSelector;
 }

--- a/src/ProcessedStory.ts
+++ b/src/ProcessedStory.ts
@@ -77,6 +77,12 @@ function normalizeWaitForSelector(waitForSelector: unknown, rawStory: StorybookS
   );
 }
 
+/**
+ * Our Parameter parsers use Zod under the hood, which works great. Unfortunately, there's no way
+ * to provide a custom error message when parsing, and its default error messages won't give users
+ * enough information about what went wrong and where. Instead we'll catch errors from the parsers
+ * and re-throw our own.
+ */
 function parseWithFriendlyError<T>(parser: () => T, errorMessage: string): T {
   try {
     return parser();
@@ -89,6 +95,10 @@ function parseWithFriendlyError<T>(parser: () => T, errorMessage: string): T {
   }
 }
 
+/**
+ * Create useful error text for an invalid param. We provide info on what parameter failed, in
+ * which component, and in what story. That way people can easily find their error.
+ */
 function createInvalidParamErrorMessage(rawStory: StorybookStory, paramName: string): string {
   return `Invalid value for parameter "${paramName}" in component "${rawStory.kind}", story "${rawStory.name}"`;
 }

--- a/src/ProcessedStory.ts
+++ b/src/ProcessedStory.ts
@@ -60,14 +60,14 @@ function normalizeSkip(skip: unknown, rawStory: StorybookStory) {
   return parseWithFriendlyError(
     () => Parameters.parseSkip(skip),
     createInvalidParamErrorMessage(rawStory, 'skip'),
-  ) || false;
+  );
 }
 
 function normalizeDisabledRules(disabledRules: unknown, rawStory: StorybookStory) {
   return parseWithFriendlyError(
     () => Parameters.parseDisabledRules(disabledRules),
     createInvalidParamErrorMessage(rawStory, 'disabledRules'),
-  ) || [];
+  );
 }
 
 function normalizeWaitForSelector(waitForSelector: unknown, rawStory: StorybookStory) {

--- a/src/ProcessedStory.ts
+++ b/src/ProcessedStory.ts
@@ -33,9 +33,18 @@ export function fromStory(rawStory: StorybookStory): ProcessedStory {
     name: rawStory.name,
     parameters: {
       axe: {
-        skip: Parameters.parseSkip(rawStory.parameters?.axe?.skip) || false,
-        disabledRules: Parameters.parseDisabledRules(rawStory.parameters?.axe?.disabledRules) || [],
-        waitForSelector: Parameters.parseWaitForSelector(rawStory.parameters?.axe?.waitForSelector),
+        skip: Parameters.parseSkip(
+          rawStory.parameters?.axe?.skip,
+          createInvalidParamErrorMessage(rawStory, 'skip'),
+        ) || false,
+        disabledRules: Parameters.parseDisabledRules(
+          rawStory.parameters?.axe?.disabledRules,
+          createInvalidParamErrorMessage(rawStory, 'disabledRules'),
+        ) || [],
+        waitForSelector: Parameters.parseWaitForSelector(
+          rawStory.parameters?.axe?.waitForSelector,
+          createInvalidParamErrorMessage(rawStory, 'waitForSelector'),
+        ),
       },
     },
     storybookId: rawStory.id,
@@ -54,4 +63,8 @@ export function isEnabled(story: ProcessedStory): boolean {
  */
 export function getDisabledRules(story: ProcessedStory): string[] {
   return story.parameters.axe.disabledRules;
+}
+
+function createInvalidParamErrorMessage(rawStory: StorybookStory, paramName: string): string {
+  return `Invalid value for parameter "${paramName}" in component "${rawStory.kind}", story "${rawStory.name}"`;
 }

--- a/tests/unit/ProcessedStory.test.ts
+++ b/tests/unit/ProcessedStory.test.ts
@@ -85,7 +85,7 @@ describe('fromStory', () => {
         },
       };
 
-      expect(() => fromStory(rawStory)).toThrow("Value of 'skip' option 'wut' is invalid");
+      expect(() => fromStory(rawStory)).toThrow('Invalid value for parameter "skip" in component "button", story "a"');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6188,3 +6188,8 @@ yazl@^2.5.1:
   integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
   dependencies:
     buffer-crc32 "~0.2.3"
+
+zod@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.8.2.tgz#f25b78bc76e64f31318d242e301c23d3d610b7a1"
+  integrity sha512-kpwVRACazsOhELVt5h4R2pC2OndrqaBK4+z134TWOsnzn7n2uOYnSyvx0QAn410pl28CgVtkSi5ew7e/AgO0oA==


### PR DESCRIPTION
Use Zod to parse story parameters. This is a precursor to adding some more options for the `waitForSelector` parameter. I wanted to use Zod for that as it gets more sophisticated eventually (i.e. taking a string or undefined or an object).