### PR TITLE
Allow `waitForSelector` to select any element in the DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [maintenance] Use [Zod](https://github.com/colinhacks/zod) to validate story parameters, instead of custom logic [#37](https://github.com/chanzuckerberg/axe-storybook-testing/pull/37)
+- [fix] Allow `waitForSelector` to select any element in the DOM (whether visible or not) [#38](https://github.com/chanzuckerberg/axe-storybook-testing/pull/38)
 
 ## 4.1.0 (2021-9-20)
 

--- a/src/browser/TestBrowser.ts
+++ b/src/browser/TestBrowser.ts
@@ -65,7 +65,7 @@ export default class TestBrowser {
     await StorybookPage.showStory(this.page, story);
 
     if (storyParams.waitForSelector) {
-      await this.page.waitForSelector(storyParams.waitForSelector);
+      await this.page.waitForSelector(storyParams.waitForSelector, { state: 'attached' });
     }
 
     return Result.fromPage(this.page, story);


### PR DESCRIPTION
Allow `waitForSelector` to select any element in the DOM (whether visible or not).

See https://github.com/chanzuckerberg/axe-storybook-testing/issues/34#issuecomment-926222115