### PR TITLE
Fix playwright serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [fix] Fix for issue [#44](https://github.com/chanzuckerberg/axe-storybook-testing/issues/44). Prevent the command from blowing up when addon parameters cannot be serialized [#45](https://github.com/chanzuckerberg/axe-storybook-testing/pull/40)
+
 ## 4.1.2 (2021-10-21)
 
 - [maintenance] Use esbuild to build the project, instead of Babel [#40](https://github.com/chanzuckerberg/axe-storybook-testing/pull/40)

--- a/bin/axe-storybook.js
+++ b/bin/axe-storybook.js
@@ -4,11 +4,11 @@
 require('../build/index')
   .run()
   .then(() => {
-    process.on('exit', () => process.exit(0));
+    process.exit(0);
   })
   .catch((error) => {
     if (error) {
       console.log(error);
     }
-    process.on('exit', () => process.exit(1));
+    process.exit(1);
   });

--- a/src/browser/StorybookPage.ts
+++ b/src/browser/StorybookPage.ts
@@ -1,5 +1,6 @@
 import type { ClientApi, StoreItem } from '@storybook/client-api';
 import type { Page } from 'playwright';
+import dedent from 'ts-dedent';
 import type { ProcessedStory } from '../ProcessedStory';
 
 /**
@@ -14,7 +15,15 @@ export async function getStories(page: Page): Promise<StorybookStory[]> {
   const rawStories = await page.evaluate(fetchStoriesFromWindow);
 
   if (!rawStories) {
-    throw new Error('Storybook object not found on window. Open your storybook and check the console for errors.');
+    throw new Error(dedent`
+      Stories could not be retrieved from storybook!
+
+      Please check the following
+      - Is storybook being successfully built into a static directory before running axe-storybook?
+      - Is axe-storybook pointing at the static storybook build? By default it looks for ./storybook-static, but that can be configured with a CLI option.
+
+      If everything looks good with those, this is likely a bug with axe-storybook-testing. Reporting a bug would be greatly appreciated!
+    `);
   }
 
   return rawStories;

--- a/src/browser/StorybookPage.ts
+++ b/src/browser/StorybookPage.ts
@@ -50,10 +50,7 @@ function fetchStoriesFromWindow(): Promise<StoreItem[]> {
           checkStories(timesCalled + 1);
         }, 100);
       } else {
-        reject(new Error(
-          'Storybook object not found on window. ' +
-          'Open your storybook and check the console for errors.',
-        ));
+        reject(new Error('Storybook object not found on window. Open your storybook and check the console for errors.'));
       }
     }
 


### PR DESCRIPTION
Fixes #44.

Playwright's [page.evaluate](https://playwright.dev/docs/api/class-page/#page-evaluate) can return `undefined` if the function we pass to it returns something that's not JSON serializable.

We're using it here to return Storybook's representation of a story, and some addon's parameters may not be serializable (for example, MSW handlers).

Fortunately, we only need a couple pieces of a story (name, id, etc), and can avoid this by only returning the specific things we need from the browser.