### PR TITLE
Simplify fetch stories

### DIFF
--- a/src/browser/StorybookPage.ts
+++ b/src/browser/StorybookPage.ts
@@ -25,12 +25,11 @@ export async function getStories(page: Page): Promise<StorybookStory[]> {
     throw new Error(dedent`
       Stories could not be retrieved from storybook!
 
-      Please check the following
-      - Is storybook being successfully built into a static directory before running axe-storybook?
-      - Is axe-storybook pointing at the static storybook build? By default it looks for ./storybook-static, but that can be configured with a CLI option.
-      - Are you using a compatible version of Storybook?
+      Please check that...
+      - You're using a compatible version of Storybook
+      - Storybook doesn't have any errors
 
-      If everything looks good with those, this is likely a bug with axe-storybook-testing. Reporting a bug would be greatly appreciated!
+      Otherwise this is likely a bug with axe-storybook-testing.
 
       Original error message: ${e}
     `);

--- a/src/browser/StorybookPage.ts
+++ b/src/browser/StorybookPage.ts
@@ -21,19 +21,20 @@ export type StorybookStory = Pick<Story, 'id' | 'kind' | 'name' | 'parameters'>;
  * Get the list of stories from a static storybook build.
  */
 export async function getStories(page: Page): Promise<StorybookStory[]> {
-  const rawStories = await pTimeout(page.evaluate(fetchStoriesFromWindow), 10_000);
-
-  if (!rawStories) {
+  const rawStories = await pTimeout(page.evaluate(fetchStoriesFromWindow), 10_000).catch(e => {
     throw new Error(dedent`
       Stories could not be retrieved from storybook!
 
       Please check the following
       - Is storybook being successfully built into a static directory before running axe-storybook?
       - Is axe-storybook pointing at the static storybook build? By default it looks for ./storybook-static, but that can be configured with a CLI option.
+      - Are you using a compatible version of Storybook?
 
       If everything looks good with those, this is likely a bug with axe-storybook-testing. Reporting a bug would be greatly appreciated!
+
+      Original error message: ${e}
     `);
-  }
+  });
 
   return rawStories;
 }

--- a/src/browser/StorybookPage.ts
+++ b/src/browser/StorybookPage.ts
@@ -1,6 +1,7 @@
 import type { AnyFramework } from '@storybook/csf';
 import type { PreviewWeb } from '@storybook/preview-web';
 import type { Story } from '@storybook/store';
+import pTimeout from 'p-timeout';
 import type { Page } from 'playwright';
 import dedent from 'ts-dedent';
 import type { ProcessedStory } from '../ProcessedStory';
@@ -20,7 +21,7 @@ export type StorybookStory = Pick<Story, 'id' | 'kind' | 'name' | 'parameters'>;
  * Get the list of stories from a static storybook build.
  */
 export async function getStories(page: Page): Promise<StorybookStory[]> {
-  const rawStories = await page.evaluate(fetchStoriesFromWindow);
+  const rawStories = await pTimeout(page.evaluate(fetchStoriesFromWindow), 10_000);
 
   if (!rawStories) {
     throw new Error(dedent`

--- a/src/formats/Spec.ts
+++ b/src/formats/Spec.ts
@@ -26,7 +26,7 @@ export function format(emitter: SuiteEmitter, print = console.log, colors = new 
   emitter.on('suiteError', (error) => {
     print(dedent`
       ${colors.red('Error! The suite failed to run')}
-      An error was encountered before we started testing stories. Likely this means the browser failed to open.
+      An error was encountered before we started testing stories.
     `);
     print('');
     print(String(error));

--- a/src/suite/Suite.ts
+++ b/src/suite/Suite.ts
@@ -107,8 +107,8 @@ export function run(options: Options): SuiteEmitter {
         await browser.close();
       }
     } catch (message) {
-      // The test suite failed to run. Likely the browser failed to open, or something else went
-      // wrong before we started iterating components.
+      // The test suite failed to run. Likely something went wrong before we started iterating
+      // components.
       const error = message instanceof Error ? message : new Error(String(message));
       emitter.emit('suiteError', error);
       // Signal that the test suite is done. Pass a failed count of 1 to indicate that the test run

--- a/tests/unit/browser/iframe.html
+++ b/tests/unit/browser/iframe.html
@@ -3,6 +3,7 @@
     <script>
       window['__STORYBOOK_PREVIEW__'] = {
         storyStore: {
+          initializationPromise: Promise.resolve(),
           raw: function() {
             return [
               {


### PR DESCRIPTION
Realized while investigating another bug that story stores have an `initializationPromise` that we can tie into, instead of polling for storybook to be ready.