### PR TITLE
Support StoryStoreV7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [maintenance] Upgrade Playwright to 1.22.1
+- [fix] Access static storybook via file server so everything works with storyStoreV7 (fixing #51)
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,9 @@
 # Changelog
 
-- [maintenance] Upgrade Playwright to 1.22.1
-- [fix] Access static storybook via file server so everything works with storyStoreV7 (fixing #51)
-
-## Unreleased
+## 5.0.1-alpha.1 (2022-05-20)
 
 - [maintenance] Upgrade all dependencies
-- [fix] Upgrade Playwright from 1.16.3 to 1.21.1
-- [fix] Upgrade Yargs from 17.2.1 to 17.4.1
+- [fix] Access static storybook via file server so everything works with storyStoreV7 (fixing #51)
 
 ## 5.0.0 (2021-11-29)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ If there are any violations, information about them will be printed, and the com
 - [Minimum requirements](#minimum-requirements)
 - [Installation](#installation)
 - [Usage](#usage)
-- [Known issue with storyStoreV7](#known-issue)
 - [Options](#options)
 - [Configuring stories](#configuring-stories)
   - [skip](#skip)
@@ -57,35 +56,6 @@ npm run storybook:axe
 # or, if using Yarn
 yarn storybook:axe
 ```
-
-## Known issue with storyStoreV7
-
-There is a [known issue](https://github.com/chanzuckerberg/axe-storybook-testing/issues/51) preventing this project from working when [storyStoreV7](https://storybook.js.org/blog/storybook-on-demand-architecture/) is set to `true`, due to https://github.com/storybookjs/storybook/issues/16967.
-
-Two workarounds are:
-
-1. Set `storyStoreV7` to `false` in .storybook/main.js
-   ```js
-   // In .storybook/main.js
-   module.exports = {
-     // ...
-     storyStoreV7: false,
-   };
-   ```
-2. Set `storyStoreV7` based on an environment variable, and turn it off when running axe-storybook-testing
-   ```js
-   // In .storybook/main.js
-   module.exports = {
-     // ...
-     storyStoreV7: process.env.NO_STORY_STORE_V7 !== 'true',
-   }
-   ```
-   ```jsonc
-   // In package.json
-   "scripts": {
-     "storybook:axe": "build-storybook && NO_STORY_STORE_V7=true axe-storybook"
-   }
-   ```
 
 ## Options
 

--- a/demo/.storybook/main.js
+++ b/demo/.storybook/main.js
@@ -5,4 +5,7 @@ module.exports = {
     "@storybook/addon-a11y",
     "@storybook/addon-postcss",
   ],
+  features: {
+    storyStoreV7: true,
+  },
 };

--- a/package.json
+++ b/package.json
@@ -44,10 +44,12 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
+    "http-server": "^14.1.0",
     "indent-string": "^4.0.0",
     "lodash": "^4.17.21",
     "p-timeout": "^4.1.0",
     "playwright": "^1.22.1",
+    "portfinder": "^1.0.28",
     "ts-dedent": "^2.2.0",
     "yargs": "^17.5.1",
     "zod": "^3.16.0"
@@ -60,6 +62,7 @@
     "@storybook/csf": "0.0.2--canary.87bc651.0",
     "@storybook/preview-web": "^6.5.0",
     "@storybook/store": "^6.5.0",
+    "@types/http-server": "^0.12.1",
     "@types/jest": "^27.5.1",
     "@types/lodash": "^4.14.182",
     "@types/node": "^17.0.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/axe-storybook-testing",
-  "version": "5.0.0",
+  "version": "5.0.1-alpha.1",
   "license": "MIT",
   "homepage": "https://github.com/chanzuckerberg/axe-storybook-testing",
   "engines": {

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,6 +1,3 @@
-import fs from 'fs';
-import path from 'path';
-import { URL } from 'url';
 import yargs from 'yargs';
 
 const options = {
@@ -63,10 +60,11 @@ export function parseOptions() {
 
   return {
     browser: getBrowser(argv.browser),
+    buildDir: argv.buildDir,
     format: getFormat(argv.format),
     failingImpacts: getFailingImpacts(argv['failing-impact']),
     headless: argv.headless,
-    iframePath: getIframePath(argv['build-dir'], argv['storybook-address']),
+    storybookAddress: argv.storybookAddress,
     pattern: new RegExp(argv.pattern),
     timeout: argv.timeout,
   };
@@ -81,33 +79,6 @@ function getBrowser(browser: string) {
     default:
       throw new Error(`Invalid browser option: "${browser}"`);
   }
-}
-
-function getIframePath(buildDir: string, storybookServer?: string) {
-  if (storybookServer !== undefined) {
-    return getIframePathFromStorybookServer(storybookServer);
-  }
-  else {
-    return getIframePathFromBuildDir(buildDir);
-  }
-}
-
-function getIframePathFromBuildDir(buildDir: string) {
-  const storybookStaticPath = path.resolve(buildDir);
-  let iframeFilePath = path.join(storybookStaticPath, 'iframe.html');
-
-  if (!fs.existsSync(iframeFilePath)) {
-    throw new Error(`Static Storybook not found at ${storybookStaticPath}. Have you called build-storybook first?`);
-  }
-
-  iframeFilePath = path.join('file://', iframeFilePath);
-
-  return iframeFilePath;
-}
-
-function getIframePathFromStorybookServer(storybookServer: string) {
-  const iframePath = new URL(storybookServer + '/iframe.html');
-  return iframePath.href;
 }
 
 function getFormat(format: string) {

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import type { Options } from './Options';
+
+/**
+ * Get the url to Storybook, based on whether we're looking at a static build or a running
+ * storybook.
+ */
+export function getStorybookUrl(options: Options): string {
+  if (options.storybookAddress) {
+    return options.storybookAddress;
+  }
+
+  const storybookStaticPath = path.resolve(options.buildDir);
+  const iframeFilePath = path.join(storybookStaticPath, 'iframe.html');
+
+  if (!fs.existsSync(iframeFilePath)) {
+    throw new Error(`Static Storybook not found at ${storybookStaticPath}. Have you called build-storybook first?`);
+  }
+
+  return 'file://' + storybookStaticPath;
+}

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -3,14 +3,37 @@ import path from 'path';
 import type { Options } from './Options';
 
 /**
- * Get the url to Storybook, based on whether we're looking at a static build or a running
- * storybook.
+ * Start up a server for the storybook build. If using a running Storybook, then just use that.
+ *
+ * Needed to work around https://github.com/chanzuckerberg/axe-storybook-testing/issues/51 and
+ * https://github.com/storybookjs/storybook/issues/16967, so Storybook can load all the stories
+ * when storyStoreV7 is used.
+ *
+ * In particular there's a stories.json file that Storybook fetches, and it can't do that if we're
+ * accessing it via file:// url.
  */
-export function getStorybookUrl(options: Options): string {
+export async function getServer(options: Options): Promise<[storybookUrl: string, start: () => Promise<void>, shutdown: () => void]> {
+  // If we have a storybook address, then storybook is already running and we just need to use that
+  // address. No need to start or stop a server, either.
   if (options.storybookAddress) {
-    return options.storybookAddress;
+    return [
+      options.storybookAddress,
+      () => Promise.resolve(),
+      () => {},
+    ];
   }
 
+  return [
+    getStaticStorybookUrl(options),
+    () => Promise.resolve(),
+    () => {},
+  ];
+}
+
+/**
+ * Get the url we'll use to access a static storybook build.
+ */
+function getStaticStorybookUrl(options: Options): string {
   const storybookStaticPath = path.resolve(options.buildDir);
   const iframeFilePath = path.join(storybookStaticPath, 'iframe.html');
 

--- a/src/browser/StorybookPage.ts
+++ b/src/browser/StorybookPage.ts
@@ -54,7 +54,7 @@ function fetchStoriesFromWindow(): Promise<StorybookStory[]> {
   const storybookPreview = window.__STORYBOOK_PREVIEW__;
   const storyStore = storybookPreview.storyStore;
 
-  return storyStore.initializationPromise.then(() => {
+  return storyStore.cacheAllCSFFiles().then(() => {
     // Pick only the properties we need from Storybook's representation of a story.
     //
     // This is necessary because Playwright's `page.evaluate` requires return values to be JSON

--- a/src/browser/TestBrowser.ts
+++ b/src/browser/TestBrowser.ts
@@ -16,13 +16,6 @@ export default class TestBrowser {
   static async create(storybookUrl: string, options: Options): Promise<TestBrowser> {
     const browser = await playwright[options.browser].launch({
       headless: options.headless,
-      args: [
-        // Allow Chrome to open one file:/// url from another. Needed because:
-        // - We open iframe.html from the local file system.
-        // - When using storyStoreV7, Storybook tries to fetch './stories.json'.
-        // - Since that fetch is coming from a file:/// url, it's also TO a file:/// url.
-        '--allow-file-access-from-files',
-      ],
     });
 
     try {

--- a/src/browser/TestBrowser.ts
+++ b/src/browser/TestBrowser.ts
@@ -24,14 +24,12 @@ export default class TestBrowser {
       // Create a new page at Storybook's static iframe and with axe-core setup and ready to run.
       const page = await context.newPage();
 
-      // Print any console logs coming from the browser.
+      // Print any console logs containing the word "error" coming from the browser, to help
+      // debugging.
       page.on('console', (message) => {
-        console.log('console log from browser:', message);
-      });
-
-      // Print any errors coming from the browser.
-      page.on('pageerror', (error) => {
-        console.log('error from browser:', error);
+        if (/error/i.test(message.text())) {
+          console.log('console log from browser:', message);
+        }
       });
 
       // Turn on `prefers-reduced-motion`. This will prevent any animations that respect the media

--- a/src/browser/TestBrowser.ts
+++ b/src/browser/TestBrowser.ts
@@ -16,6 +16,13 @@ export default class TestBrowser {
   static async create(options: Options): Promise<TestBrowser> {
     const browser = await playwright[options.browser].launch({
       headless: options.headless,
+      args: [
+        // Allow Chrome to open one file:/// url from another. Needed because:
+        // - We open iframe.html from the local file system.
+        // - When using storyStoreV7, Storybook tries to fetch './stories.json'.
+        // - Since that fetch is coming from a file:/// url, it's also TO a file:/// url.
+        '--allow-file-access-from-files',
+      ],
     });
 
     try {

--- a/src/browser/TestBrowser.ts
+++ b/src/browser/TestBrowser.ts
@@ -24,6 +24,16 @@ export default class TestBrowser {
       // Create a new page at Storybook's static iframe and with axe-core setup and ready to run.
       const page = await context.newPage();
 
+      // Print any console logs coming from the browser.
+      page.on('console', (message) => {
+        console.log('console log from browser:', message);
+      });
+
+      // Print any errors coming from the browser.
+      page.on('pageerror', (error) => {
+        console.log('error from browser:', error);
+      });
+
       // Turn on `prefers-reduced-motion`. This will prevent any animations that respect the media
       // query from causing flaky or failing tests due to animation.
       await page.emulateMedia({ reducedMotion: 'reduce' });

--- a/src/browser/TestBrowser.ts
+++ b/src/browser/TestBrowser.ts
@@ -13,7 +13,7 @@ export default class TestBrowser {
    * Create a new test browser instance that knows how to use Storybook and Axe. Needed because
    * constructors can't be async.
    */
-  static async create(options: Options): Promise<TestBrowser> {
+  static async create(storybookUrl: string, options: Options): Promise<TestBrowser> {
     const browser = await playwright[options.browser].launch({
       headless: options.headless,
       args: [
@@ -46,7 +46,7 @@ export default class TestBrowser {
       await page.emulateMedia({ reducedMotion: 'reduce' });
 
       // Visit Storybook's static iframe.
-      await page.goto(options.iframePath);
+      await page.goto(storybookUrl + '/iframe.html');
 
       // Ensure axe-core is setup and ready to run.
       await AxePage.prepare(page);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { parseOptions } from './Options';
+import { getStorybookUrl } from './Server';
 import findFormat from './formats/findFormat';
 import { run as runSuite } from './suite/Suite';
 
@@ -10,7 +11,7 @@ export function run(): Promise<void> {
   return new Promise((resolve, reject) => {
     const options = parseOptions();
     const format = findFormat(options);
-    const emitter = runSuite(options);
+    const emitter = runSuite(getStorybookUrl(options), options);
 
     emitter.on('suiteFinish', (_browser, _numPass, numFail) => {
       return numFail > 0 ? reject() : resolve();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { parseOptions } from './Options';
-import { getStorybookUrl } from './Server';
+import { getServer } from './Server';
 import findFormat from './formats/findFormat';
 import { run as runSuite } from './suite/Suite';
 
@@ -7,13 +7,18 @@ import { run as runSuite } from './suite/Suite';
  * Run the accessibility tests and return a promise that is resolved or rejected based on whether
  * any violations were detected.
  */
-export function run(): Promise<void> {
+export async function run(): Promise<void> {
+  const options = parseOptions();
+  const format = findFormat(options);
+  const [storybookUrl, startServer, shutdownServer] = await getServer(options);
+
+  await startServer();
+
   return new Promise((resolve, reject) => {
-    const options = parseOptions();
-    const format = findFormat(options);
-    const emitter = runSuite(getStorybookUrl(options), options);
+    const emitter = runSuite(storybookUrl, options);
 
     emitter.on('suiteFinish', (_browser, _numPass, numFail) => {
+      shutdownServer();
       return numFail > 0 ? reject() : resolve();
     });
 

--- a/src/suite/Suite.ts
+++ b/src/suite/Suite.ts
@@ -33,7 +33,7 @@ export type SuiteEmitter = Emitter<SuiteEvents>;
  * Find Storybook stories and run Axe on each one. Returns an event emitter that emits events when
  * components and stories are processed.
  */
-export function run(options: Options): SuiteEmitter {
+export function run(storybookUrl: string, options: Options): SuiteEmitter {
   const emitter = createEmitter<SuiteEvents>();
 
   defer(async () => {
@@ -46,7 +46,7 @@ export function run(options: Options): SuiteEmitter {
 
     // Get the Storybook stories.
     try {
-      const browser = await Browser.create(options);
+      const browser = await Browser.create(storybookUrl, options);
       const stories = await browser.getStories();
       const storiesByComponent = groupBy(stories, 'componentName');
       const storiesAndComponents = Object.entries(storiesByComponent);

--- a/tests/integration/__snapshots__/integration.test.ts.snap
+++ b/tests/integration/__snapshots__/integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`failing specific impact levels 1`] = `
 "$ axe-storybook --failing-impact critical
+Serving up 🍕 static storybook build at: http://127.0.0.1:8000
 [chromium] accessibility
   delays
     ✓ Short Delay And Pass
@@ -138,6 +139,7 @@ info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this comm
 
 exports[`filtering the components to run 1`] = `
 "$ axe-storybook --pattern simple
+Serving up 🍕 static storybook build at: http://127.0.0.1:8000
 [chromium] accessibility
   [skipped] delays
     - Short Delay And Pass
@@ -252,6 +254,7 @@ info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this comm
 
 exports[`outputting accessibility violation information for the demo app 1`] = `
 "$ axe-storybook
+Serving up 🍕 static storybook build at: http://127.0.0.1:8000
 [chromium] accessibility
   delays
     ✓ Short Delay And Pass

--- a/tests/unit/browser/iframe.html
+++ b/tests/unit/browser/iframe.html
@@ -3,7 +3,7 @@
     <script>
       window['__STORYBOOK_PREVIEW__'] = {
         storyStore: {
-          initializationPromise: Promise.resolve(),
+          cacheAllCSFFiles: () => Promise.resolve(),
           raw: function() {
             return [
               {

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,12 +796,26 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/connect@*":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
+  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
   integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   dependencies:
     "@types/node" "*"
+
+"@types/http-server@^0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@types/http-server/-/http-server-0.12.1.tgz#025f916420673f5ebc5ea48987aeae27776f02ac"
+  integrity sha512-OJ8zs0o8JuHo92KCCsLq4BqkHPi1+Aj2yoPQXJ18LPUxOA1lqKfgBLtHNAQTwwPzeBqyo+HDkWD91MkfOGvNJg==
+  dependencies:
+    "@types/connect" "*"
 
 "@types/is-function@^1.0.0":
   version "1.0.1"
@@ -1076,6 +1090,13 @@ array.prototype.flatmap@^1.3.0:
     es-abstract "^1.19.2"
     es-shim-unscopables "^1.0.0"
 
+async@^2.6.2:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
+  dependencies:
+    lodash "^4.17.14"
+
 axe-core@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.2.tgz#dcf7fb6dea866166c3eab33d68208afe4d5f670c"
@@ -1145,6 +1166,13 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+basic-auth@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1311,6 +1339,11 @@ core-js@^3.6.5, core-js@^3.8.2:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.22.5.tgz#a5f5a58e663d5c0ebb4e680cd7be37536fb2a9cf"
   integrity sha512-VP/xYuvJ0MJWRAobcmQ8F2H6Bsn+s7zqAAjFaHGBMc5AQm7zaelhD1LGduFn2EehEcQcU+br6t+fwbpQ5d1ZWA==
 
+corser@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/corser/-/corser-2.0.1.tgz#8eda252ecaab5840dcd975ceb90d9370c819ff87"
+  integrity sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1327,7 +1360,7 @@ debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^3.2.7:
+debug@^3.1.1, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -1802,6 +1835,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eventemitter3@^4.0.0:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -1914,6 +1952,11 @@ flatted@^3.1.0:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
+
+follow-redirects@^1.0.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
+  integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2091,15 +2134,62 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+html-encoding-sniffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
+  integrity sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==
+  dependencies:
+    whatwg-encoding "^2.0.0"
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+http-proxy@^1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
+
+http-server@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/http-server/-/http-server-14.1.0.tgz#51d43e03cdbb94f328b24821cad2cefc6c6a2eed"
+  integrity sha512-5lYsIcZtf6pdR8tCtzAHTWrAveo4liUlJdWc7YafwK/maPgYHs+VNP6KpCClmUnSorJrARVMXqtT055zBv11Yg==
+  dependencies:
+    basic-auth "^2.0.1"
+    chalk "^4.1.2"
+    corser "^2.0.1"
+    he "^1.2.0"
+    html-encoding-sniffer "^3.0.0"
+    http-proxy "^1.18.1"
+    mime "^1.6.0"
+    minimist "^1.2.5"
+    opener "^1.5.1"
+    portfinder "^1.0.28"
+    secure-compare "3.0.1"
+    union "~0.5.0"
+    url-join "^4.0.1"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ignore@^5.2.0:
   version "5.2.0"
@@ -2820,7 +2910,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2888,6 +2978,11 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2907,10 +3002,17 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
+mkdirp@^0.5.5:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
 
 ms@2.0.0:
   version "2.0.0"
@@ -3027,6 +3129,11 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+opener@^1.5.1:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -3164,6 +3271,15 @@ playwright@^1.22.1:
   dependencies:
     playwright-core "1.22.1"
 
+portfinder@^1.0.28:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
+  integrity sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==
+  dependencies:
+    async "^2.6.2"
+    debug "^3.1.1"
+    mkdirp "^0.5.5"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -3215,7 +3331,7 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@^6.10.0:
+qs@^6.10.0, qs@^6.4.0:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
@@ -3281,6 +3397,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -3339,10 +3460,15 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 scheduler@^0.22.0:
   version "0.22.0"
@@ -3350,6 +3476,11 @@ scheduler@^0.22.0:
   integrity sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==
   dependencies:
     loose-envify "^1.1.0"
+
+secure-compare@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
+  integrity sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=
 
 semver@7.x, semver@^7.3.5, semver@^7.3.7:
   version "7.3.7"
@@ -3690,12 +3821,24 @@ unfetch@^4.2.0:
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
   integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
+union@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/union/-/union-0.5.0.tgz#b2c11be84f60538537b846edb9ba266ba0090075"
+  integrity sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==
+  dependencies:
+    qs "^6.4.0"
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
 
 util-deprecate@^1.0.2:
   version "1.0.2"
@@ -3722,6 +3865,13 @@ walker@^1.0.7:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+whatwg-encoding@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
+  integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
+  dependencies:
+    iconv-lite "0.6.3"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR resolves #51 so that everything works when using `storyStoreV7: true`.

It does so by accessing the static storybook build via a simple file server, instead of directly navigating to the file:// url, and avoiding https://github.com/storybookjs/storybook/issues/16967.