### PR TITLE
Mkahn add story timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,19 @@ If there are any violations, information about them will be printed, and the com
 
 ## Table of contents
 
-- [Minimum requirements](#minimum-requirements)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Options](#options)
-- [Configuring stories](#configuring-stories)
-  - [skip](#skip)
-  - [disabledRules](#disabledrules)
-- [Developing](#developing)
-- [Inspiration](#inspiration)
+- [@chanzuckerberg/axe-storybook-testing](#chanzuckerbergaxe-storybook-testing)
+  - [Table of contents](#table-of-contents)
+  - [Minimum requirements](#minimum-requirements)
+  - [Installation](#installation)
+  - [Usage](#usage)
+  - [Options](#options)
+  - [Configuring stories](#configuring-stories)
+    - [skip](#skip)
+    - [disabledRules](#disabledrules)
+    - [timeout](#timeout)
+    - [waitForSelector](#waitforselector)
+  - [Developing](#developing)
+  - [Inspiration](#inspiration)
 
 ## Minimum requirements
 
@@ -125,6 +129,20 @@ export const parameters = {
     disabledRules: ['select-name'],
   },
 };
+```
+
+### timeout
+
+Overrides global `--timeout` for this specific test
+
+```jsx
+// SomeComponent.stories.jsx
+
+SomeStory.parameters = {
+  axe: {
+    timeout: 5000,
+  },
+}
 ```
 
 ### waitForSelector

--- a/demo/src/delays.stories.jsx
+++ b/demo/src/delays.stories.jsx
@@ -66,6 +66,20 @@ export const MediumDelayAndFail = {
   },
 };
 
+export const MediumDelayAndShortTimeoutFail = {
+  render: () => (
+    <Delay
+      // Should be UNDER the test timeout, which is 2000ms by default.
+      delay={500}
+    >
+      <button id="hi">hello world</button>
+    </Delay>
+  ),
+  parameters: {
+    axe: { waitForSelector: '#hi', timeout: 100 },
+  },
+};
+
 export const LongDelayAndTimeout = {
   render: () => (
     <Delay

--- a/src/ProcessedStory.ts
+++ b/src/ProcessedStory.ts
@@ -3,10 +3,11 @@ import type { StorybookStory } from './browser/StorybookPage';
 
 type Params = {
   skip: boolean;
-  disabledRules: string[],
+  disabledRules: string[];
+  timeout: number;
   /** @deprecated */
-  waitForSelector?: string,
-}
+  waitForSelector?: string;
+};
 
 /**
  * Story with normalized and custom properties needed by this project.
@@ -25,6 +26,7 @@ export default class ProcessedStory {
       skip: normalizeSkip(rawStory.parameters?.axe?.skip, rawStory),
       disabledRules: normalizeDisabledRules(rawStory.parameters?.axe?.disabledRules, rawStory),
       waitForSelector: normalizeWaitForSelector(rawStory.parameters?.axe?.waitForSelector, rawStory),
+      timeout: normalizeTimeout(rawStory.parameters?.axe?.timeout, rawStory),
     };
   }
 
@@ -36,6 +38,10 @@ export default class ProcessedStory {
     return this.parameters.disabledRules;
   }
 
+  get timeout() {
+    return this.parameters.timeout;
+  }
+
   /** @deprecated */
   get waitForSelector() {
     return this.parameters.waitForSelector;
@@ -45,6 +51,7 @@ export default class ProcessedStory {
 const skipSchema = zod.boolean();
 const disabledRulesSchema = zod.array(zod.string());
 const waitForSelectorSchema = zod.optional(zod.string());
+const timeoutSchema = zod.number().gte(0).lte(60000);
 
 function normalizeSkip(skip: unknown, rawStory: StorybookStory) {
   return parseWithFriendlyError(
@@ -59,6 +66,14 @@ function normalizeDisabledRules(disabledRules: unknown, rawStory: StorybookStory
     () => disabledRulesSchema.optional().parse(disabledRules) || [],
     rawStory,
     'disabledRules',
+  );
+}
+
+function normalizeTimeout(timeout: unknown, rawStory: StorybookStory) {
+  return parseWithFriendlyError(
+    () => timeoutSchema.optional().parse(timeout) || 0,
+    rawStory,
+    'timeout',
   );
 }
 

--- a/src/ProcessedStory.ts
+++ b/src/ProcessedStory.ts
@@ -51,7 +51,7 @@ export default class ProcessedStory {
 const skipSchema = zod.boolean();
 const disabledRulesSchema = zod.array(zod.string());
 const waitForSelectorSchema = zod.optional(zod.string());
-const timeoutSchema = zod.number().gte(0).lte(60000);
+const timeoutSchema = zod.number().gte(0);
 
 function normalizeSkip(skip: unknown, rawStory: StorybookStory) {
   return parseWithFriendlyError(

--- a/src/Suite.ts
+++ b/src/Suite.ts
@@ -63,9 +63,13 @@ export async function runSuite(storybookUrl: string, options: Options): Promise<
         }
       });
 
+      if (story.timeout) {
+        test.timeout(story.timeout);
+      }
+
       // Skip this test if the story is disabled. Equivalent to writing `it.skip(...)`.
       if (!story.isEnabled) {
-       test.pending = true;
+        test.pending = true;
       }
 
       componentSuite.addTest(test);

--- a/src/Suite.ts
+++ b/src/Suite.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import indent from 'indent-string';
 import each from 'lodash/each';
 import groupBy from 'lodash/groupBy';
-import Mocha, { Runnable } from 'mocha';
+import Mocha from 'mocha';
 import type { Options } from './Options';
 import Browser from './browser';
 
@@ -66,7 +66,7 @@ export async function runSuite(storybookUrl: string, options: Options): Promise<
           assert.fail(error);
         }
       });
-  
+
       // Skip this test if the story is disabled. Equivalent to writing `it.skip(...)`.
       if (!story.isEnabled) {
         test.pending = true;

--- a/src/Suite.ts
+++ b/src/Suite.ts
@@ -42,7 +42,7 @@ export async function runSuite(storybookUrl: string, options: Options): Promise<
       // Create a test for this story.
       const test = new Mocha.Test(story.name, async function () {
         if (story.timeout) {
-          // @ts-ignore -- Mocha's TS definitions don't properly type `this`
+          // @ts-expect-error -- Mocha's TS definitions don't properly type `this`
           this.timeout(story.timeout);
         }
         const result = await browser.getResultForStory(story);


### PR DESCRIPTION
Adding a `timeout` param to the axe config that overrides the global timeout.  Closes #58

VSCode also re-wrote the table of contents and fixed some semi-colons, both of which I think are fine.