### PR TITLE
[1] export AxeParams for typing in traject and axe-storybook-testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,6 @@ storybook-static
 
 # Non-Yarn lockfiles
 package-lock.json
+
+# Editor Config directory
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ storybook-static
 
 # Non-Yarn lockfiles
 package-lock.json
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- [new] Export types for Story parameters
 
 ## 6.1.0 (2022-07-07)
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ SomeStory.parameters = {
 ### disabledRules
 
 Prevent axe-storybook-testing from running specific Axe rules on a story by using the `disabledRules` parameter.
+Array elements should be the name of [axe-core](https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md.) rules.
 
 ```jsx
 // SomeComponent.stories.jsx
@@ -133,7 +134,7 @@ export const parameters = {
 
 ### timeout
 
-Overrides global `--timeout` for this specific test
+Overrides global `--timeout` for this specific test. (in ms)
 
 ```jsx
 // SomeComponent.stories.jsx

--- a/README.md
+++ b/README.md
@@ -170,6 +170,24 @@ SomeStory.play = async () => {
 };
 ```
 
+## Type Safety
+axe-storybook-testing provides Typescript types for the story parameters listed above.
+Story parameters can be type checked by augmenting Storybook's `Parameter` type like so:
+
+```ts
+// SomeTypescriptModule.d.ts
+
+import type {AxeParams} from '@chanzuckerberg/axe-storybook-testing';
+...
+declare module '@storybook/react' {
+  // Augment Storybook's definition of Parameters so it contains valid options for axe-storybook-testing
+  interface Parameters {
+    axe?: AxeParams;
+  }
+}
+...
+```
+
 ## Developing
 
 If you want to work on this project or contribute back to it, see our [wiki entry on Development setup](https://github.com/chanzuckerberg/axe-storybook-testing/wiki/Development-setup).

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+export declare type AxeParams = {
+    /**
+     * Prevents axe-storybook-testing from running Axe rules on this story.
+     */
+    skip?: boolean;
+    /**
+     * Prevents axe-storybook-testing from running specific Axe rules on this story.
+     * NOTE: array elements should be the names of axe-core rules found in
+     * https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md.
+     */
+    disabledRules?: string[];
+    /**
+     * Overrides the global timeout for this specific test (in ms)
+     */
+    timeout?: number;
+    /**
+     * @deprecated
+     * Legacy way of waiting for a selector before running Axe.
+     */
+    waitForSelector?: string;
+};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "main": "build/index.js",
   "files": [
     "bin",
-    "build"
+    "build",
+    "index.d.ts"
   ],
   "publishConfig": {
     "access": "public"

--- a/src/ProcessedStory.ts
+++ b/src/ProcessedStory.ts
@@ -1,6 +1,22 @@
 import { z as zod } from 'zod';
 import type { StorybookStory } from './browser/StorybookPage';
-import type { AxeParams } from './index';
+
+export type AxeParams = {
+  /**
+   * Prevents axe-storybook-testing from running Axe rules on this story.
+   */
+  skip?: boolean;
+  /**
+   * Prevents axe-storybook-testing from running specific Axe rules on this story.
+   * NOTE: array elements should be the names of axe-core rules found in
+   * https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md.
+   */
+  disabledRules?: string[];
+  /**
+   * Overrides the global timeout for this specific test (in ms)
+   */
+  timeout?: number;
+};
 
 type Params = AxeParams & {
   /** @deprecated */

--- a/src/ProcessedStory.ts
+++ b/src/ProcessedStory.ts
@@ -1,10 +1,8 @@
 import { z as zod } from 'zod';
 import type { StorybookStory } from './browser/StorybookPage';
+import type { AxeParams } from './index';
 
-type Params = {
-  skip: boolean;
-  disabledRules: string[];
-  timeout: number;
+type Params = AxeParams & {
   /** @deprecated */
   waitForSelector?: string;
 };
@@ -24,8 +22,14 @@ export default class ProcessedStory {
     this.id = rawStory.id;
     this.parameters = {
       skip: normalizeSkip(rawStory.parameters?.axe?.skip, rawStory),
-      disabledRules: normalizeDisabledRules(rawStory.parameters?.axe?.disabledRules, rawStory),
-      waitForSelector: normalizeWaitForSelector(rawStory.parameters?.axe?.waitForSelector, rawStory),
+      disabledRules: normalizeDisabledRules(
+        rawStory.parameters?.axe?.disabledRules,
+        rawStory,
+      ),
+      waitForSelector: normalizeWaitForSelector(
+        rawStory.parameters?.axe?.waitForSelector,
+        rawStory,
+      ),
       timeout: normalizeTimeout(rawStory.parameters?.axe?.timeout, rawStory),
     };
   }
@@ -61,7 +65,10 @@ function normalizeSkip(skip: unknown, rawStory: StorybookStory) {
   );
 }
 
-function normalizeDisabledRules(disabledRules: unknown, rawStory: StorybookStory) {
+function normalizeDisabledRules(
+  disabledRules: unknown,
+  rawStory: StorybookStory,
+) {
   return parseWithFriendlyError(
     () => disabledRulesSchema.optional().parse(disabledRules) || [],
     rawStory,
@@ -77,7 +84,10 @@ function normalizeTimeout(timeout: unknown, rawStory: StorybookStory) {
   );
 }
 
-function normalizeWaitForSelector(waitForSelector: unknown, rawStory: StorybookStory) {
+function normalizeWaitForSelector(
+  waitForSelector: unknown,
+  rawStory: StorybookStory,
+) {
   return parseWithFriendlyError(
     () => waitForSelectorSchema.parse(waitForSelector),
     rawStory,
@@ -91,12 +101,18 @@ function normalizeWaitForSelector(waitForSelector: unknown, rawStory: StorybookS
  * enough information about what went wrong and where. Instead we'll catch errors from the parsers
  * and re-throw our own.
  */
-function parseWithFriendlyError<T>(parser: () => T, rawStory: StorybookStory, paramName: string): T {
+function parseWithFriendlyError<T>(
+  parser: () => T,
+  rawStory: StorybookStory,
+  paramName: string,
+): T {
   try {
     return parser();
   } catch (message) {
     if (message instanceof zod.ZodError) {
-      throw new TypeError(`Invalid value for parameter "${paramName}" in component "${rawStory.kind}", story "${rawStory.name}"`);
+      throw new TypeError(
+        `Invalid value for parameter "${paramName}" in component "${rawStory.kind}", story "${rawStory.name}"`,
+      );
     } else {
       throw message;
     }

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -9,7 +9,12 @@ import { analyze } from './browser/AxePage';
  * These rules aren't useful/helpful in the context of Storybook stories, and we disable them when
  * running Axe.
  */
-const defaultDisabledRules = ['bypass', 'landmark-one-main', 'page-has-heading-one', 'region'];
+const defaultDisabledRules = [
+  'bypass',
+  'landmark-one-main',
+  'page-has-heading-one',
+  'region',
+];
 
 /**
  * Violations reported by Axe for a story.
@@ -19,7 +24,8 @@ export default class Result {
    * Run Axe on a browser page that is displaying a story.
    */
   static async fromPage(page: Page, story: ProcessedStory) {
-    const disabledRules = [...defaultDisabledRules, ...story.disabledRules];
+    const disabledRulesFromStory = story.disabledRules || [];
+    const disabledRules = [...defaultDisabledRules, ...disabledRulesFromStory];
     const axeResults = await analyze(page, disabledRules);
     return new Result(axeResults.violations);
   }
@@ -40,7 +46,7 @@ export default class Result {
       return this.violations.length === 0;
     }
 
-    return this.violations.every(violation => {
+    return this.violations.every((violation) => {
       return !failingImpacts.includes(String(violation.impact));
     });
   }
@@ -62,7 +68,7 @@ function formatViolation(violation: AxeResult, index: number) {
 
        Check these nodes:
 
-       ${violation.nodes.map(formatNode).join('\n\n') }
+       ${violation.nodes.map(formatNode).join('\n\n')}
   `;
 }
 
@@ -70,7 +76,7 @@ function formatNode(node: NodeResult) {
   if (node.failureSummary) {
     return dedent`
       - html: ${node.html}
-        summary: ${indent(node.failureSummary, 11).trimStart() }
+        summary: ${indent(node.failureSummary, 11).trimStart()}
     `;
   }
   return `- html: ${node.html}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,11 @@ import { parseOptions } from './Options';
 import { runWithServer } from './Server';
 import { runSuite } from './Suite';
 
+export type AxeParams = {
+  skip?: boolean;
+  disabledRules?: string[];
+  timeout?: number;
+};
 /**
  * Run the accessibility tests and return a promise that is resolved or rejected based on whether
  * any violations were detected.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,8 @@ import { parseOptions } from './Options';
 import { runWithServer } from './Server';
 import { runSuite } from './Suite';
 
-export type AxeParams = {
-  skip?: boolean;
-  disabledRules?: string[];
-  timeout?: number;
-};
+export type {AxeParams} from './ProcessedStory';
+
 /**
  * Run the accessibility tests and return a promise that is resolved or rejected based on whether
  * any violations were detected.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "outDir": "build",
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2015",
+    "target": "es2015"
   }
 }


### PR DESCRIPTION
[sc-205389]

### This PR
Exports a type for storybook parameters (`AxeParams`) that can be consumed by another app for type checking purposes. Apps will have to define the type like so
```ts
import type {AxeParams} from '@chanzuckerberg/axe-storybook-testing';

declare module '@storybook/react' {
  interface Parameters {
    axe?: AxeParams;
  }
}
```

### Motivation
Centralize type definitions for our API so other apps don't have to define their own.

### Alternative Approaches

One might ask "why require other apps to augment Storybook's Parameters type? can't we do that in our repo?" I tried making this approach work for a couple days and couldn't. The problem I ran into seems to be a scoping issue -- it appears that augmenting the types of a third-party package that belongs to the same project that our package belongs to isn't possible. 
