### PR TITLE
[Draft] export a single types.d.ts declaration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ packages/*/yarn.lock
 
 # Output directories
 /build
+/types
 
 # Packed npm
 *.tgz

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "main": "build/index.js",
   "files": [
     "bin",
-    "build"
+    "build",
+    "types/types.d.ts"
   ],
   "publishConfig": {
     "access": "public"

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+export type AxeParams = {
+  /**
+   * Prevents axe-storybook-testing from running Axe rules on this story.
+   */
+  skip?: boolean;
+  /**
+   * Prevents axe-storybook-testing from running specific Axe rules on this story.
+   * NOTE: array elements should be the names of axe-core rules found in
+   * https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md.
+   */
+  disabledRules?: string[];
+  /**
+   * Overrides the global timeout for this specific test (in ms)
+   */
+  timeout?: number;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "es2015",
-    "declaration": true
-  }
+    "declaration": true,
+    "declarationDir": "./types"
+  },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,6 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "es2015",
+    "declaration": true
   }
 }


### PR DESCRIPTION
Inspired by conversation in #61, try to export a single `types` declaration file from this package to be used by other apps. 

### Initial approach

create a type declaration file `src/index.d.ts` with the type I wanted to export. 
```ts
// src/index.d.ts

export type AxeParams = {
  ...
}
```

I expected that with the current tsconfig options the `index.d.ts` file would make its way into our `build/` output directory. Unfortunately this wasn't the case. 

### Current Approach
1. set `declaration: true` to generate `.d.ts` files for all built files and output them to a `./types` folder
2. in our `package.json`, add `types/types.d.ts` to the list of files we export in our package