### PR TITLE
Export types for Story parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- [new] Export types for Story parameters
 
 ## 6.1.0 (2022-07-07)
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ SomeStory.play = async () => {
 };
 ```
 
+## Type Safety
+axe-storybook-testing provides Typescript types for the story parameters listed above.
+Story parameters can be type checked by augmenting Storybook's `Parameter` type like so:
+
+```ts
+// SomeTypescriptModule.d.ts
+
+import type {AxeParams} from '@chanzuckerberg/axe-storybook-testing';
+...
+declare module '@storybook/react' {
+  // Augment Storybook's definition of Parameters so it contains valid options for axe-storybook-testing
+  interface Parameters {
+    axe?: AxeParams;
+  }
+}
+...
+```
+
 ## Developing
 
 If you want to work on this project or contribute back to it, see our [wiki entry on Development setup](https://github.com/chanzuckerberg/axe-storybook-testing/wiki/Development-setup).

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,21 @@
 export declare type AxeParams = {
-    /**
-     * Prevents axe-storybook-testing from running Axe rules on this story.
-     */
-    skip?: boolean;
-    /**
-     * Prevents axe-storybook-testing from running specific Axe rules on this story.
-     * NOTE: array elements should be the names of axe-core rules found in
-     * https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md.
-     */
-    disabledRules?: string[];
-    /**
-     * Overrides the global timeout for this specific test (in ms)
-     */
-    timeout?: number;
-    /**
-     * @deprecated
-     * Legacy way of waiting for a selector before running Axe.
-     */
-    waitForSelector?: string;
+  /**
+   * Prevents axe-storybook-testing from running Axe rules on this story.
+   */
+  skip?: boolean;
+  /**
+   * Prevents axe-storybook-testing from running specific Axe rules on this story.
+   * NOTE: array elements should be the names of axe-core rules found in
+   * https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md.
+   */
+  disabledRules?: string[];
+  /**
+   * Overrides the global timeout for this specific test (in ms)
+   */
+  timeout?: number;
+  /**
+   * @deprecated
+   * Legacy way of waiting for a selector before running Axe.
+   */
+  waitForSelector?: string;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+export declare type AxeParams = {
+    /**
+     * Prevents axe-storybook-testing from running Axe rules on this story.
+     */
+    skip?: boolean;
+    /**
+     * Prevents axe-storybook-testing from running specific Axe rules on this story.
+     * NOTE: array elements should be the names of axe-core rules found in
+     * https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md.
+     */
+    disabledRules?: string[];
+    /**
+     * Overrides the global timeout for this specific test (in ms)
+     */
+    timeout?: number;
+    /**
+     * @deprecated
+     * Legacy way of waiting for a selector before running Axe.
+     */
+    waitForSelector?: string;
+};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "main": "build/index.js",
   "files": [
     "bin",
-    "build"
+    "build",
+    "index.d.ts"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
[sc-205389]

### This PR
Exports a type for storybook parameters (AxeParams) that can be consumed by another app for type checking purposes. Apps will have to define the type like so

```ts
import type {AxeParams} from '@chanzuckerberg/axe-storybook-testing';

declare module '@storybook/react' {
  interface Parameters {
    axe?: AxeParams;
  }
}
```
### Motivation
Centralize type definitions for our API so other apps don't have to define their own.

**Note:** 
This PR is the result of a discussion in #61. Created a new request so the change is easier to follow.