### PR TITLE
Add ability to specify runOptions in story config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [new] Export types for Story parameters
 - [maintenance] Update all dependencies
+- [new] Allow use of axe runOptions for stories [#65]https://github.com/chanzuckerberg/axe-storybook-testing/pull/65)
 
 ## 6.1.0 (2022-07-07)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ yarn add --dev @chanzuckerberg/axe-storybook-testing
 ## Usage
 
 To use:
+
 1. Create a static Storybook build. Normally you'll do this with the [build-storybook command](https://storybook.js.org/docs/react/api/cli-options#build-storybook).
 2. Run `axe-storybook`, which will analyze the static build.
 
@@ -68,17 +69,17 @@ yarn storybook:axe
 
 The command-line interface has the following options:
 
-Option               |Default           |Values                                    |Description
----------------------|------------------|------------------------------------------|-
-`--browser`          |`chromium`        |chromium, firefox, webkit                 |Which browser to run the tests in
-`--build-dir`        |`storybook-static`|path                                      |Storybook static build directory
-`--failing-impact`   |`all`             |all, minor, moderate, serious, critical   |The lowest impact level that should be considered a failure
-`--headless`         |`true`            |boolean                                   |Whether to run headlessly or not
-`--pattern`          |`.*`              |regex pattern                             |Only run tests that match a component name pattern
-`--reporter`         |`spec`            |spec, dot, nyan, tap, landing, list, progress, json, json-stream, min, doc, markdown, xunit|How to display the test run. Can be any [built-in Mocha reporter](https://mochajs.org/#reporters).
-`--reporter-options` |                  |string                                    |Options to pass to the mocha reporter. Especially useful with the xunit reporter - e.g. `--reporter-options output=./filename.xml`
-`--storybook-address`|                  |url                                       |Storybook server address to test against instead of using a static build directory. If set, `--build-dir` will be ignored. e.g. `--storybook-address http://localhost:6006`
-`--timeout`          |2000              |number                                    |Timeout (in milliseconds) for each test
+| Option                | Default            | Values                                                                                      | Description                                                                                                                                                                 |
+| --------------------- | ------------------ | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--browser`           | `chromium`         | chromium, firefox, webkit                                                                   | Which browser to run the tests in                                                                                                                                           |
+| `--build-dir`         | `storybook-static` | path                                                                                        | Storybook static build directory                                                                                                                                            |
+| `--failing-impact`    | `all`              | all, minor, moderate, serious, critical                                                     | The lowest impact level that should be considered a failure                                                                                                                 |
+| `--headless`          | `true`             | boolean                                                                                     | Whether to run headlessly or not                                                                                                                                            |
+| `--pattern`           | `.*`               | regex pattern                                                                               | Only run tests that match a component name pattern                                                                                                                          |
+| `--reporter`          | `spec`             | spec, dot, nyan, tap, landing, list, progress, json, json-stream, min, doc, markdown, xunit | How to display the test run. Can be any [built-in Mocha reporter](https://mochajs.org/#reporters).                                                                          |
+| `--reporter-options`  |                    | string                                                                                      | Options to pass to the mocha reporter. Especially useful with the xunit reporter - e.g. `--reporter-options output=./filename.xml`                                          |
+| `--storybook-address` |                    | url                                                                                         | Storybook server address to test against instead of using a static build directory. If set, `--build-dir` will be ignored. e.g. `--storybook-address http://localhost:6006` |
+| `--timeout`           | 2000               | number                                                                                      | Timeout (in milliseconds) for each test                                                                                                                                     |
 
 For example, to run non-headlessly in Firefox, you would run
 
@@ -152,6 +153,24 @@ export const SomeStory = {
     },
   },
 };
+```
+
+### runOptions
+
+Allows use of any of the available [`axe.run`](https://www.deque.com/axe/core-documentation/api-documentation/#options-parameter) options. See the link for more details. When using `runOptions.rules` in combination with `disabledRules`, **`disabledRules` will always take precedent.**
+
+```jsx
+
+export const SomeStory = {
+  parameters: {
+    axe: {
+      runOptions: {
+        preload: true,
+        selectors: true,
+        ...
+      }
+    }
+  };
 ```
 
 ### waitForSelector

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { RunOptions } from 'axe-core';
+
 export declare type AxeParams = {
   /**
    * Prevents axe-storybook-testing from running Axe rules on this story.
@@ -13,6 +15,11 @@ export declare type AxeParams = {
    * Overrides the global timeout for this specific test (in ms)
    */
   timeout?: number;
+  /**
+   * Allows use of optional axe.run options for a given story
+   * @see https://www.deque.com/axe/core-documentation/api-documentation/#options-parameter
+   */
+  runOptions?: RunOptions;
   /**
    * @deprecated
    * Legacy way of waiting for a selector before running Axe.

--- a/src/ProcessedStory.ts
+++ b/src/ProcessedStory.ts
@@ -42,24 +42,31 @@ export default class ProcessedStory {
     };
   }
 
-  // Determines if the test should be skipped in runSuite()
+  /**
+   * Determines if the test should be skipped in runSuite()
+   */
   get isEnabled() {
     return !this.parameters.skip;
   }
 
-  // Run option for rules to disable in a given story
-  // TODO: mark as deprecated and suggest using `runOptions` instead?
+  /**
+   * Run option for rules to disable in a given story
+   */
   get disabledRules() {
     return this.parameters.disabledRules;
   }
 
-  // All optional run options used for a given story
-  // @see https://www.deque.com/axe/core-documentation/api-documentation/#options-parameter
+  /**
+   * All optional run options used for a given story
+   * @see https://www.deque.com/axe/core-documentation/api-documentation/#options-parameter
+   */
   get runOptions() {
     return this.parameters.runOptions;
   }
 
-  // Timeout override for a test triggered in runSuite()
+  /**
+   * Timeout override for a test triggered in runSuite()
+   */
   get timeout() {
     return this.parameters.timeout;
   }

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -25,7 +25,7 @@ export default class Result {
    */
   static async fromPage(page: Page, story: ProcessedStory) {
     const disabledRules = [...defaultDisabledRules, ...story.disabledRules];
-    const axeResults = await analyze(page, disabledRules);
+    const axeResults = await analyze(page, disabledRules, story.runOptions);
     return new Result(axeResults.violations);
   }
 

--- a/src/browser/AxePage.ts
+++ b/src/browser/AxePage.ts
@@ -16,8 +16,9 @@ export async function prepare(page: Page): Promise<void> {
 export function analyze(
   page: Page,
   disabledRules: string[] = [],
+  runOptions: RunOptions = {},
 ): Promise<AxeResults> {
-  return page.evaluate(runAxe, getOptions({}, disabledRules));
+  return page.evaluate(runAxe, getRunOptions(runOptions, disabledRules));
 }
 
 function runAxe(options: RunOptions): Promise<AxeResults> {
@@ -26,13 +27,24 @@ function runAxe(options: RunOptions): Promise<AxeResults> {
   return window.axeQueue.add(() => window.axe.run(document, options));
 }
 
-function getOptions(options: RunOptions, disabledRules: string[] = []) {
+export function getRunOptions(
+  options: RunOptions,
+  disabledRules: string[] = [],
+): RunOptions {
   const newRules: RuleObject = options.rules || {};
 
   for (const rule of disabledRules) {
     newRules[rule] = { enabled: false };
   }
 
+  /**
+   * TODO-ah: if `options.rules` AND disabledRules exist, we should:
+   * - merge the two together (preserves API and call signatures)
+   * - overwrite any rules from `runOptions` with those based on defaults and `disabledRules`
+   * Also:
+   * - throw a warning in case of deprecation approach?
+   * - throw an error in case of deprecation approach?
+   *  */
   return {
     ...options,
     rules: newRules,

--- a/src/browser/AxePage.ts
+++ b/src/browser/AxePage.ts
@@ -37,14 +37,6 @@ export function getRunOptions(
     newRules[rule] = { enabled: false };
   }
 
-  /**
-   * TODO-ah: if `options.rules` AND disabledRules exist, we should:
-   * - merge the two together (preserves API and call signatures)
-   * - overwrite any rules from `runOptions` with those based on defaults and `disabledRules`
-   * Also:
-   * - throw a warning in case of deprecation approach?
-   * - throw an error in case of deprecation approach?
-   *  */
   return {
     ...options,
     rules: newRules,

--- a/tests/unit/AxePage.test.ts
+++ b/tests/unit/AxePage.test.ts
@@ -1,0 +1,14 @@
+import { getRunOptions } from '../../src/browser/AxePage';
+
+describe('getRunOptions', () => {
+  it('overrides any rules from runOptions with those from disabledRules', () => {
+    const runOptions = {
+      rules: { 'color-contrast': { enabled: true } },
+    };
+    const disabledRules = ['color-contrast'];
+
+    expect(getRunOptions(runOptions, disabledRules)).toEqual({
+      rules: { 'color-contrast': { enabled: false } },
+    });
+  });
+});

--- a/tests/unit/ProcessedStory.test.ts
+++ b/tests/unit/ProcessedStory.test.ts
@@ -75,3 +75,51 @@ describe('disabledRules', () => {
     );
   });
 });
+
+describe('runOptions', () => {
+  it('is an empty object when runOptions parameter is missing', () => {
+    const parameters = { axe: {} };
+    const rawStory = { id: 'button--a', kind: 'button', name: 'a', parameters };
+    const processedStory = new ProcessedStory(rawStory);
+
+    expect(processedStory.runOptions).toEqual({});
+  });
+
+  it('can parse fully formatted rule entries in runOptions', () => {
+    const parameters = {
+      axe: { runOptions: { rules: { 'color-contrast': { enabled: true } } } },
+    };
+    const rawStory = { id: 'button--a', kind: 'button', name: 'a', parameters };
+    const processedStory = new ProcessedStory(rawStory);
+
+    expect(processedStory.runOptions).toEqual({
+      rules: { 'color-contrast': { enabled: true } },
+    });
+  });
+
+  it('preserves both disabledRules and any rules in runOptions.rules', () => {
+    const parameters = {
+      axe: {
+        disabledRules: ['color-contrast'],
+        runOptions: { rules: { 'color-contrast': { enabled: true } } },
+      },
+    };
+    const rawStory = { id: 'button--a', kind: 'button', name: 'a', parameters };
+    const processedStory = new ProcessedStory(rawStory);
+
+    expect(processedStory.runOptions).toEqual({
+      rules: { 'color-contrast': { enabled: true } },
+    });
+    expect(processedStory.disabledRules).toEqual(['color-contrast']);
+  });
+
+  it('throws an error if a key does not conform to the documented options shape', () => {
+    // @see https://www.deque.com/axe/core-documentation/api-documentation/#options-parameter
+    const parameters = { axe: { runOptions: { selector: 'invalid' } } };
+    const rawStory = { id: 'button--a', kind: 'button', name: 'a', parameters };
+
+    expect(() => new ProcessedStory(rawStory)).toThrow(
+      'Invalid value for parameter "runOptions" in component "button", story "a"',
+    );
+  });
+});


### PR DESCRIPTION
[sc-205390] (Fixes #50)

- specify schema for RunOptions type, and use to pass down run options ultimately to axe.run
- define override of rules when both runOptions.rules and disabledRules is present
- add unit tests to cover updated methods