### PR TITLE
mode parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [maintenance] Update all dependencies
 - [maintenance] Prune unneeded dependencies
+- [new] Add `mode` option to Story parameters. Most useful for its `warn` option, which will print errors detected for a story but not fail the test suite.
 
 ## 6.2.0 (2022-09-29)
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ If there are any violations, information about them will be printed, and the com
   - [Usage](#usage)
   - [Options](#options)
   - [Story parameters](#story-parameters)
-    - [skip](#skip)
     - [disabledRules](#disabledrules)
+    - [skip](#skip)
     - [timeout](#timeout)
     - [waitForSelector](#waitforselector)
   - [TypeScript](#typescript)
@@ -95,22 +95,6 @@ yarn storybook:axe --headless false --browser firefox
 
 Stories can use parameters to configure how axe-storybook-testing handles them.
 
-### skip
-
-Prevent axe-storybook-testing from running a story by using the `skip` parameter.
-
-```jsx
-// SomeComponent.stories.jsx
-
-export const SomeStory = {
-  parameters: {
-    axe: {
-      skip: true,
-    },
-  },
-};
-```
-
 ### disabledRules
 
 Prevent axe-storybook-testing from running specific Axe rules on a story by using the `disabledRules` parameter.
@@ -139,22 +123,6 @@ export const parameters = {
 };
 ```
 
-### timeout
-
-Overrides global `--timeout` for this specific test
-
-```jsx
-// SomeComponent.stories.jsx
-
-export const SomeStory = {
-  parameters: {
-    axe: {
-      timeout: 5000,
-    },
-  },
-};
-```
-
 ### runOptions
 
 Allows use of any of the available [`axe.run`](https://www.deque.com/axe/core-documentation/api-documentation/#options-parameter) options. See the link for more details. When using `runOptions.rules` in combination with `disabledRules`, **`disabledRules` will always take precedent.**
@@ -171,6 +139,38 @@ export const SomeStory = {
       }
     }
   };
+```
+
+### skip
+
+Prevent axe-storybook-testing from running a story by using the `skip` parameter.
+
+```jsx
+// SomeComponent.stories.jsx
+
+export const SomeStory = {
+  parameters: {
+    axe: {
+      skip: true,
+    },
+  },
+};
+```
+
+### timeout
+
+Overrides global `--timeout` for this specific test
+
+```jsx
+// SomeComponent.stories.jsx
+
+export const SomeStory = {
+  parameters: {
+    axe: {
+      timeout: 5000,
+    },
+  },
+};
 ```
 
 ### waitForSelector

--- a/README.md
+++ b/README.md
@@ -123,6 +123,24 @@ export const parameters = {
 };
 ```
 
+### mode
+
+Set whether errors for a story will fail the test suite or not.
+
+Valid options are:
+- `off` - the story will be skipped and axe will not run on it. This is the same as setting `skip: true`.
+- `error` (default) - axe errors will fail the test suite for a story.
+
+```jsx
+// .storybook/preview.js
+
+export const parameters = {
+  axe: {
+    mode: 'off',
+  },
+};
+```
+
 ### runOptions
 
 Allows use of any of the available [`axe.run`](https://www.deque.com/axe/core-documentation/api-documentation/#options-parameter) options. See the link for more details. When using `runOptions.rules` in combination with `disabledRules`, **`disabledRules` will always take precedent.**
@@ -143,7 +161,7 @@ export const SomeStory = {
 
 ### skip
 
-Prevent axe-storybook-testing from running a story by using the `skip` parameter.
+Prevent axe-storybook-testing from running a story by using the `skip` parameter. This is shorthand for setting `mode: 'off'`.
 
 ```jsx
 // SomeComponent.stories.jsx

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Set whether errors for a story will fail the test suite or not.
 
 Valid options are:
 - `off` - the story will be skipped and axe will not run on it. This is the same as setting `skip: true`.
-- `warn` - axe errors will be printed, but won't fail the test suite.
+- `warn` - axe errors will be printed, but won't fail the test suite. Stories with this set will show up as pending.
 - `error` (default) - axe errors will fail the test suite for a story.
 
 ```jsx
@@ -137,7 +137,7 @@ Valid options are:
 
 export const parameters = {
   axe: {
-    mode: 'off',
+    mode: 'warn',
   },
 };
 ```

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Set whether errors for a story will fail the test suite or not.
 
 Valid options are:
 - `off` - the story will be skipped and axe will not run on it. This is the same as setting `skip: true`.
+- `warn` - axe errors will be printed, but won't fail the test suite.
 - `error` (default) - axe errors will fail the test suite for a story.
 
 ```jsx

--- a/demo/src/simple.stories.jsx
+++ b/demo/src/simple.stories.jsx
@@ -25,6 +25,20 @@ export const FailureColorContrastSkipped = {
   },
 };
 
+export const FailureColorContrastWarn = {
+  ...FailureColorContrast,
+  parameters: {
+    axe: {mode: 'warn'},
+  },
+};
+
+export const FailureColorContrastOff = {
+  ...FailureColorContrast,
+  parameters: {
+    axe: {mode: 'off'},
+  },
+};
+
 export const FailureNoDiscernibleTextAndInvalidRoleSkipped = {
   ...FailureNoDiscernibleTextAndInvalidRole,
   parameters: {

--- a/demo/src/simple.stories.jsx
+++ b/demo/src/simple.stories.jsx
@@ -32,6 +32,13 @@ export const FailureColorContrastWarn = {
   },
 };
 
+export const FailureNoDiscernibleTextWarn = {
+  render: () => <button></button>,
+  parameters: {
+    axe: {mode: 'warn'},
+  },
+};
+
 export const FailureColorContrastOff = {
   ...FailureColorContrast,
   parameters: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ export declare type AxeParams = {
   disabledRules?: string[];
   /**
    * Set whether violations in a story should cause the test suite to fail or not. Valid options
-   * are 'off' and 'error'.
+   * are 'off', warn, and 'error'.
    */
   mode?: 'off' | 'warn' | 'error';
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ export declare type AxeParams = {
    * Set whether violations in a story should cause the test suite to fail or not. Valid options
    * are 'off' and 'error'.
    */
-  mode?: 'off' | 'error';
+  mode?: 'off' | 'warn' | 'error';
   /**
    * Overrides the global timeout for this specific test (in ms)
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,8 @@ import type {RunOptions} from 'axe-core';
 
 export declare type AxeParams = {
   /**
-   * Prevents axe-storybook-testing from running Axe rules on this story.
+   * Prevents axe-storybook-testing from running Axe rules on this story. Shorthand for
+   * `mode: 'off'`.
    */
   skip?: boolean;
   /**
@@ -11,6 +12,11 @@ export declare type AxeParams = {
    * https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md.
    */
   disabledRules?: string[];
+  /**
+   * Set whether violations in a story should cause the test suite to fail or not. Valid options
+   * are 'off' and 'error'.
+   */
+  mode?: 'off' | 'error';
   /**
    * Overrides the global timeout for this specific test (in ms)
    */

--- a/src/ProcessedStory.ts
+++ b/src/ProcessedStory.ts
@@ -4,7 +4,7 @@ import type {StorybookStory} from './browser/StorybookPage';
 
 type Params = {
   disabledRules: string[];
-  mode: 'off' | 'error';
+  mode: 'off' | 'warn' | 'error';
   runOptions?: RunOptions;
   skip: boolean;
   timeout: number;
@@ -87,7 +87,7 @@ export default class ProcessedStory {
 }
 
 const disabledRulesSchema = zod.array(zod.string());
-const modeSchema = zod.enum(['off', 'error']).optional();
+const modeSchema = zod.enum(['off', 'warn', 'error']).optional();
 const skipSchema = zod.boolean();
 const timeoutSchema = zod.number().gte(0);
 const waitForSelectorSchema = zod.optional(zod.string());

--- a/src/Suite.ts
+++ b/src/Suite.ts
@@ -65,12 +65,18 @@ export async function runSuite(
           // twice. It seems that the stack trace includes the error message, for some reason.
           error.stack = '';
 
-          assert.fail(error);
+          // Fail the test suite if the story is supposed to be able to do that. Either way the
+          // error message is displayed.
+          if (story.canFail) {
+            assert.fail(error);
+          } else {
+            assert.ok(true, error);
+          }
         }
       });
 
       // Skip this test if the story is disabled. Equivalent to writing `it.skip(...)`.
-      if (!story.isEnabled) {
+      if (!story.shouldSkip) {
         test.pending = true;
       }
 

--- a/src/Suite.ts
+++ b/src/Suite.ts
@@ -17,6 +17,7 @@ export async function runSuite(
   const browser = await Browser.create(storybookUrl, options);
   const stories = await browser.getStories();
   const storiesByComponent = groupBy(stories, 'componentTitle');
+  const skippedErrors: Error[] = [];
 
   const mocha = new Mocha({
     reporter: options.reporter,
@@ -25,6 +26,17 @@ export async function runSuite(
   });
 
   mocha.suite.title = suiteTitle;
+
+  // Print info about any errors that were skipped but did not fail the test suite. This happens
+  // when a story has `mode: 'skip'`.
+  mocha.suite.afterAll(() => {
+    if (skippedErrors.length > 0) {
+      console.log(
+        `${skippedErrors.length} violations were detected in stories with "mode" set to "warn", so did not fail the test suite:\n\n`,
+        skippedErrors.join('\n\n'),
+      );
+    }
+  });
 
   // Make sure the test browser closes after everything has finished.
   mocha.suite.afterAll(async () => {
@@ -70,13 +82,16 @@ export async function runSuite(
           if (story.canFail) {
             assert.fail(error);
           } else {
-            assert.ok(true, error);
+            error.message = `${componentTitle} / ${story.name} / ${error.message}`;
+            skippedErrors.push(error);
+            // @ts-expect-error -- Mocha's TS definitions don't properly type `this`
+            this.skip();
           }
         }
       });
 
       // Skip this test if the story is disabled. Equivalent to writing `it.skip(...)`.
-      if (!story.shouldSkip) {
+      if (story.shouldSkip) {
         test.pending = true;
       }
 

--- a/tests/integration/__snapshots__/integration.test.ts.snap
+++ b/tests/integration/__snapshots__/integration.test.ts.snap
@@ -22,14 +22,34 @@ Serving up 🍕 static storybook build at: http://127.0.0.1:8000
     ✔ Failure Color Contrast
     6) Failure No Discernible Text And Invalid Role
     - Failure Color Contrast Skipped
+    ✔ Failure Color Contrast Warn
+    - Failure No Discernible Text Warn
+    - Failure Color Contrast Off
     - Failure No Discernible Text And Invalid Role Skipped
     ✔ Failure Color Contrast Disabled Rule
     7) Failure No Discernible Text And Invalid Role Disabled One Rule
     ✔ Failure No Discernible Text And Invalid Role Disabled Rules
 
+1 violations were detected in stories with "mode" set to "warn", so did not fail the test suite:
 
-  7 passing
-  2 pending
+ Error: simple / Failure No Discernible Text Warn / Detected the following accessibility violations!
+
+     1. button-name (Buttons must have discernible text)
+
+        For more info, visit https://dequeuniversity.com/rules/axe/4.6/button-name?application=axeAPI.
+
+        Check these nodes:
+
+        - html: <button></button>
+          summary: Fix any of the following:
+                     Element does not have inner text that is visible to screen readers
+                     aria-label attribute does not exist or is empty
+                     aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+                     Element has no title attribute
+                     Element's default semantics were not overridden with role="none" or role="presentation"
+
+  8 passing
+  4 pending
   7 failing
 
   1) delays
@@ -169,14 +189,46 @@ Serving up 🍕 static storybook build at: http://127.0.0.1:8000
     2) Failure Color Contrast
     3) Failure No Discernible Text And Invalid Role
     - Failure Color Contrast Skipped
+    - Failure Color Contrast Warn
+    - Failure No Discernible Text Warn
+    - Failure Color Contrast Off
     - Failure No Discernible Text And Invalid Role Skipped
     ✔ Failure Color Contrast Disabled Rule
     4) Failure No Discernible Text And Invalid Role Disabled One Rule
     ✔ Failure No Discernible Text And Invalid Role Disabled Rules
 
+2 violations were detected in stories with "mode" set to "warn", so did not fail the test suite:
+
+ Error: simple / Failure Color Contrast Warn / Detected the following accessibility violations!
+
+     1. color-contrast (Elements must have sufficient color contrast)
+
+        For more info, visit https://dequeuniversity.com/rules/axe/4.6/color-contrast?application=axeAPI.
+
+        Check these nodes:
+
+        - html: <button style="background-color: red; color: hotpink;">hello world</button>
+          summary: Fix any of the following:
+                     Element has insufficient color contrast of 1.51 (foreground color: #ff69b4, background color: #ff0000, font size: 10.0pt (13.3333px), font weight: normal). Expected contrast ratio of 4.5:1
+
+Error: simple / Failure No Discernible Text Warn / Detected the following accessibility violations!
+
+     1. button-name (Buttons must have discernible text)
+
+        For more info, visit https://dequeuniversity.com/rules/axe/4.6/button-name?application=axeAPI.
+
+        Check these nodes:
+
+        - html: <button></button>
+          summary: Fix any of the following:
+                     Element does not have inner text that is visible to screen readers
+                     aria-label attribute does not exist or is empty
+                     aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+                     Element has no title attribute
+                     Element's default semantics were not overridden with role="none" or role="presentation"
 
   3 passing
-  9 pending
+  12 pending
   4 failing
 
   1) simple
@@ -289,14 +341,46 @@ Serving up 🍕 static storybook build at: http://127.0.0.1:8000
     6) Failure Color Contrast
     7) Failure No Discernible Text And Invalid Role
     - Failure Color Contrast Skipped
+    - Failure Color Contrast Warn
+    - Failure No Discernible Text Warn
+    - Failure Color Contrast Off
     - Failure No Discernible Text And Invalid Role Skipped
     ✔ Failure Color Contrast Disabled Rule
     8) Failure No Discernible Text And Invalid Role Disabled One Rule
     ✔ Failure No Discernible Text And Invalid Role Disabled Rules
 
+2 violations were detected in stories with "mode" set to "warn", so did not fail the test suite:
+
+ Error: simple / Failure Color Contrast Warn / Detected the following accessibility violations!
+
+     1. color-contrast (Elements must have sufficient color contrast)
+
+        For more info, visit https://dequeuniversity.com/rules/axe/4.6/color-contrast?application=axeAPI.
+
+        Check these nodes:
+
+        - html: <button style="background-color: red; color: hotpink;">hello world</button>
+          summary: Fix any of the following:
+                     Element has insufficient color contrast of 1.51 (foreground color: #ff69b4, background color: #ff0000, font size: 10.0pt (13.3333px), font weight: normal). Expected contrast ratio of 4.5:1
+
+Error: simple / Failure No Discernible Text Warn / Detected the following accessibility violations!
+
+     1. button-name (Buttons must have discernible text)
+
+        For more info, visit https://dequeuniversity.com/rules/axe/4.6/button-name?application=axeAPI.
+
+        Check these nodes:
+
+        - html: <button></button>
+          summary: Fix any of the following:
+                     Element does not have inner text that is visible to screen readers
+                     aria-label attribute does not exist or is empty
+                     aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
+                     Element has no title attribute
+                     Element's default semantics were not overridden with role="none" or role="presentation"
 
   6 passing
-  2 pending
+  5 pending
   8 failing
 
   1) delays

--- a/tests/unit/ProcessedStory.test.ts
+++ b/tests/unit/ProcessedStory.test.ts
@@ -14,29 +14,55 @@ it('parses a raw Storybook story', () => {
   expect(processedStory.id).toEqual('button--a');
 });
 
-describe('isEnabled', () => {
-  it('is false when the skip parameter is true', () => {
-    const parameters = {axe: {skip: true}};
+describe('canFail', () => {
+  it('is true when mode is "error"', () => {
+    const parameters = {axe: {mode: 'error'}};
     const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
     const processedStory = new ProcessedStory(rawStory);
 
-    expect(processedStory.isEnabled).toEqual(false);
+    expect(processedStory.canFail).toEqual(true);
   });
 
-  it('is true when the skip parameter is false', () => {
-    const parameters = {axe: {skip: false}};
+  it('is false when mode is "off"', () => {
+    const parameters = {axe: {mode: 'off'}};
     const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
     const processedStory = new ProcessedStory(rawStory);
 
-    expect(processedStory.isEnabled).toEqual(true);
+    expect(processedStory.canFail).toEqual(false);
   });
 
-  it('is true when the skip parameter is missing', () => {
+  it('is true when mode is missing', () => {
     const parameters = {axe: {}};
     const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
     const processedStory = new ProcessedStory(rawStory);
 
-    expect(processedStory.isEnabled).toEqual(true);
+    expect(processedStory.canFail).toEqual(true);
+  });
+});
+
+describe('shouldSkip', () => {
+  it('is true when the skip parameter is true', () => {
+    const parameters = {axe: {skip: true}};
+    const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
+    const processedStory = new ProcessedStory(rawStory);
+
+    expect(processedStory.shouldSkip).toEqual(true);
+  });
+
+  it('is false when the skip parameter is false', () => {
+    const parameters = {axe: {skip: false}};
+    const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
+    const processedStory = new ProcessedStory(rawStory);
+
+    expect(processedStory.shouldSkip).toEqual(false);
+  });
+
+  it('is false when the skip parameter is missing', () => {
+    const parameters = {axe: {}};
+    const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
+    const processedStory = new ProcessedStory(rawStory);
+
+    expect(processedStory.shouldSkip).toEqual(false);
   });
 
   it('throws an error when the skip parameter is not a boolean', () => {
@@ -46,6 +72,47 @@ describe('isEnabled', () => {
     expect(() => new ProcessedStory(rawStory)).toThrow(
       'Invalid value for parameter "skip" in component "button", story "a"',
     );
+  });
+
+  it('is true when the mode parameter is "off"', () => {
+    const parameters = {axe: {mode: 'off'}};
+    const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
+    const processedStory = new ProcessedStory(rawStory);
+
+    expect(processedStory.shouldSkip).toEqual(true);
+  });
+
+  it('is false when the mode parameter is "error"', () => {
+    const parameters = {axe: {mode: 'error'}};
+    const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
+    const processedStory = new ProcessedStory(rawStory);
+
+    expect(processedStory.shouldSkip).toEqual(false);
+  });
+
+  it('is false when the mode parameter is missing', () => {
+    const parameters = {axe: {}};
+    const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
+    const processedStory = new ProcessedStory(rawStory);
+
+    expect(processedStory.shouldSkip).toEqual(false);
+  });
+
+  it('throws an error when the mode parameter is not a string', () => {
+    const parameters = {axe: {mode: true}};
+    const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
+
+    expect(() => new ProcessedStory(rawStory)).toThrow(
+      'Invalid value for parameter "mode" in component "button", story "a"',
+    );
+  });
+
+  it('defers to "skip" when both "mode" and "skip" are present', () => {
+    const parameters = {axe: {skip: true, mode: 'error'}};
+    const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
+    const processedStory = new ProcessedStory(rawStory);
+
+    expect(processedStory.shouldSkip).toEqual(true);
   });
 });
 

--- a/tests/unit/ProcessedStory.test.ts
+++ b/tests/unit/ProcessedStory.test.ts
@@ -31,6 +31,14 @@ describe('canFail', () => {
     expect(processedStory.canFail).toEqual(false);
   });
 
+  it('is false when mode is "warn"', () => {
+    const parameters = {axe: {mode: 'warn'}};
+    const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
+    const processedStory = new ProcessedStory(rawStory);
+
+    expect(processedStory.canFail).toEqual(false);
+  });
+
   it('is true when mode is missing', () => {
     const parameters = {axe: {}};
     const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
@@ -80,6 +88,14 @@ describe('shouldSkip', () => {
     const processedStory = new ProcessedStory(rawStory);
 
     expect(processedStory.shouldSkip).toEqual(true);
+  });
+
+  it('is false when the mode parameter is "warn"', () => {
+    const parameters = {axe: {mode: 'warn'}};
+    const rawStory = {id: 'button--a', kind: 'button', name: 'a', parameters};
+    const processedStory = new ProcessedStory(rawStory);
+
+    expect(processedStory.shouldSkip).toEqual(false);
   });
 
   it('is false when the mode parameter is "error"', () => {


### PR DESCRIPTION
Fixes #69 by adding a `mode` option, which can be set to:
- `off` - same as `skip: true`
- `warn` - finds and prints axe violations, but doesn't fail the test suite
- `error` - fail on axe violations