### PR TITLE
Build for es2017 instead of es2015

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [fix] Build for Node 12 / ES2017. Node 12 is the minimum supported version of Node for this project.
+
 ## 7.1.1 (2023-05-17)
 
 - [fix] Replace @storybook/preview-web peer dependency with @storybook/preview-api (which is what @storybook/react actually uses)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "outDir": "build",
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2015",
+    "target": "es2017",
   }
 }


### PR DESCRIPTION
Build for es2017 instead of es2015
- This project officially supports Node 12 and up
- https://node.green/#ES2017 says Node 12 fully supports es2017
- Building for es2017 means simpler generated code and smaller package size