### PR TITLE
Add items from CZI open source guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ If there are any violations, information about them will be printed, and the com
 
 - [@chanzuckerberg/axe-storybook-testing](#chanzuckerbergaxe-storybook-testing)
   - [Table of contents](#table-of-contents)
+  - [Code of conduct](#code-of-conduct)
   - [Minimum requirements](#minimum-requirements)
   - [Installation](#installation)
   - [Usage](#usage)
@@ -24,6 +25,10 @@ If there are any violations, information about them will be printed, and the com
   - [TypeScript](#typescript)
   - [Developing](#developing)
   - [Inspiration](#inspiration)
+
+## Code of conduct
+
+This project adheres to the [Contributor Covenant code of conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). By participating, you are expected to uphold this code. Please report unacceptable behavior to <opensource@chanzuckerberg.com>.
 
 ## Minimum requirements
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If there are any violations, information about them will be printed, and the com
   - [waitForSelector](#waitforselector) (deprecated)
 - [TypeScript](#typescript)
 - [Developing](#developing)
+- [Security](#security)
 - [Inspiration](#inspiration)
 
 ## Code of conduct
@@ -259,6 +260,10 @@ export const SomeStory: StoryObj<Args> = {
 ## Developing
 
 If you want to work on this project or contribute back to it, see our [wiki entry on Development setup](https://github.com/chanzuckerberg/axe-storybook-testing/wiki/Development-setup).
+
+## Security
+
+To report security issues, see [./SECURITY.md](./SECURITY.md).
 
 ## Inspiration
 

--- a/README.md
+++ b/README.md
@@ -8,23 +8,21 @@ If there are any violations, information about them will be printed, and the com
 
 ## Table of contents
 
-- [@chanzuckerberg/axe-storybook-testing](#chanzuckerbergaxe-storybook-testing)
-  - [Table of contents](#table-of-contents)
-  - [Code of conduct](#code-of-conduct)
-  - [Minimum requirements](#minimum-requirements)
-  - [Installation](#installation)
-  - [Usage](#usage)
-  - [Options](#options)
-  - [Story parameters](#story-parameters)
-    - [disabledRules](#disabledrules)
-    - [mode](#mode)
-    - [runOptions](#runoptions)
-    - [skip](#skip)
-    - [timeout](#timeout)
-    - [waitForSelector](#waitforselector) (deprecated)
-  - [TypeScript](#typescript)
-  - [Developing](#developing)
-  - [Inspiration](#inspiration)
+- [Code of conduct](#code-of-conduct)
+- [Minimum requirements](#minimum-requirements)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Options](#options)
+- [Story parameters](#story-parameters)
+  - [disabledRules](#disabledrules)
+  - [mode](#mode)
+  - [runOptions](#runoptions)
+  - [skip](#skip)
+  - [timeout](#timeout)
+  - [waitForSelector](#waitforselector) (deprecated)
+- [TypeScript](#typescript)
+- [Developing](#developing)
+- [Inspiration](#inspiration)
 
 ## Code of conduct
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,1 @@
+If you believe you have found a security issue, we would appreciate notification. Please send email to <security@chanzuckerberg.com>.


### PR DESCRIPTION
This PR adds items such as security and code of conduct documentation, from the [CZI open source guidelines](https://czi.atlassian.net/wiki/x/votOcQ).