### PR TITLE
Wait a random amount of time before selecting a port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [fix] Wait a random amount of time before selecting a port, to try to avoid port conflicts when multiple test runs start at the same time [#92](https://github.com/chanzuckerberg/axe-storybook-testing/pull/92)
+
 # 8.0.0 (2024-03-05)
 
 - [breaking] Support Node >= 18 [#91](https://github.com/chanzuckerberg/axe-storybook-testing/pull/91)

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -43,6 +43,10 @@ async function getServer(options: Options): Promise<Server> {
     };
   }
 
+  // Try to prevent port conflicts when multiple test runs start at the exact same time (such as in
+  // a monorepo).
+  await waitRandomTime(500);
+
   const localPath = getStaticStorybookPath(options);
   const port = await portfinder.getPortPromise();
   const host = '127.0.0.1';
@@ -77,4 +81,9 @@ function getStaticStorybookPath(options: Options): string {
   }
 
   return storybookStaticPath;
+}
+
+function waitRandomTime(maxWaitTime: number) {
+  const waitTime = Math.floor(Math.random() * maxWaitTime);
+  return new Promise((resolve) => setTimeout(resolve, waitTime));
 }


### PR DESCRIPTION
To try to avoid port conflicts when multiple test runs start at the same time.