### PR TITLE
Simplify promise queue implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [fix] Simplify the promise queue implementation [#102](https://github.com/chanzuckerberg/axe-storybook-testing/pull/102)
+
 ## 8.2.0
 
 - [new] Add parameter for Axe `context` [#98](https://github.com/chanzuckerberg/axe-storybook-testing/pull/98)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [fix] Simplify the promise queue implementation [#102](https://github.com/chanzuckerberg/axe-storybook-testing/pull/102)
+- [fix] Minor code re-organizations [#102](https://github.com/chanzuckerberg/axe-storybook-testing/pull/102)
 
 ## 8.2.0
 

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -6,17 +6,6 @@ import type ProcessedStory from './ProcessedStory';
 import {analyze} from './browser/AxePage';
 
 /**
- * These rules aren't useful/helpful in the context of Storybook stories, and we disable them when
- * running Axe.
- */
-const defaultDisabledRules = [
-  'bypass',
-  'landmark-one-main',
-  'page-has-heading-one',
-  'region',
-];
-
-/**
  * Violations reported by Axe for a story.
  */
 export default class Result {
@@ -24,10 +13,9 @@ export default class Result {
    * Run Axe on a browser page that is displaying a story.
    */
   static async fromPage(page: Page, story: ProcessedStory) {
-    const disabledRules = [...defaultDisabledRules, ...story.disabledRules];
     const axeResults = await analyze(
       page,
-      disabledRules,
+      story.disabledRules,
       story.runOptions,
       story.context,
       story.config,

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -29,10 +29,10 @@ export default class Result {
 
   toString(): string {
     return dedent`
-    Detected the following accessibility violations!
+      Detected the following accessibility violations!
 
-    ${this.violations.map(formatViolation).join('\n\n')}
-  `;
+      ${this.violations.map(formatViolation).join('\n\n')}
+    `;
   }
 }
 

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -1,28 +1,11 @@
 import type {Result as AxeResult, NodeResult} from 'axe-core';
 import indent from 'indent-string';
-import type {Page} from 'playwright';
 import dedent from 'ts-dedent';
-import type ProcessedStory from './ProcessedStory';
-import {analyze} from './browser/AxePage';
 
 /**
  * Violations reported by Axe for a story.
  */
 export default class Result {
-  /**
-   * Run Axe on a browser page that is displaying a story.
-   */
-  static async fromPage(page: Page, story: ProcessedStory) {
-    const axeResults = await analyze(
-      page,
-      story.disabledRules,
-      story.runOptions,
-      story.context,
-      story.config,
-    );
-    return new Result(axeResults.violations);
-  }
-
   violations: AxeResult[];
 
   constructor(violations: AxeResult[]) {

--- a/src/browser/AxePage.ts
+++ b/src/browser/AxePage.ts
@@ -20,6 +20,17 @@ export type Context =
   | SerialContextObject;
 
 /**
+ * These rules aren't useful/helpful in the context of Storybook stories, and we disable them when
+ * running Axe.
+ */
+const defaultDisabledRules = [
+  'bypass',
+  'landmark-one-main',
+  'page-has-heading-one',
+  'region',
+];
+
+/**
  * Prepare a page for running axe on it.
  */
 export async function prepare(page: Page): Promise<void> {
@@ -39,7 +50,10 @@ export function analyze(
   config?: Spec,
 ): Promise<AxeResults> {
   return page.evaluate(runAxe, {
-    options: getRunOptions(runOptions, disabledRules),
+    options: getRunOptions(runOptions, [
+      ...defaultDisabledRules,
+      ...disabledRules,
+    ]),
     config,
     context,
   });

--- a/src/browser/AxePage.ts
+++ b/src/browser/AxePage.ts
@@ -92,16 +92,13 @@ export function getRunOptions(
 }
 
 /**
- * Add a Queue implementation for promises, forcing a single promise to run at a time.
+ * Add a promise queue so we can ensure only one promise runs at a time.
  *
- * This will be used to ensure that we only run one `axe.run` call at a time. We will never
- * intentionally run multiple at a time. However, a component throwing an error during its
- * lifecycle can result in a test finishing and proceeding to the next one, but the previous
- * `axe.run` call still "running" when the next one starts. This results in an error (see
- * https://github.com/dequelabs/axe-core/issues/1041).
+ * Used to prevent concurrent runs of `axe.run`, which breaks (see https://github.com/dequelabs/axe-core/issues/1041).
+ * This should never happen, but in the past errors during rendering at the right/wrong time has
+ * caused the next test to start before the previous has stopped.
  *
- * We avoid that by forcing one `axe.run` call to finish before the next one can start. Got the
- * idea from https://github.com/dequelabs/agnostic-axe/pull/6.
+ * Got the idea from https://github.com/dequelabs/agnostic-axe/pull/6.
  */
 function addPromiseQueue() {
   let queue = Promise.resolve();

--- a/src/browser/AxePage.ts
+++ b/src/browser/AxePage.ts
@@ -105,7 +105,7 @@ function addPromiseQueue() {
 
   window.enqueuePromise = function <T>(createPromise: () => Promise<T>) {
     return new Promise<T>((resolve, reject) => {
-      queue = queue.then(createPromise).then(resolve, reject);
+      queue = queue.then(createPromise).then(resolve).catch(reject);
     });
   };
 }

--- a/src/browser/TestBrowser.ts
+++ b/src/browser/TestBrowser.ts
@@ -80,7 +80,15 @@ export default class TestBrowser {
       });
     }
 
-    return Result.fromPage(this.page, story);
+    const axeResults = await AxePage.analyze(
+      this.page,
+      story.disabledRules,
+      story.runOptions,
+      story.context,
+      story.config,
+    );
+
+    return new Result(axeResults.violations);
   }
 
   /**


### PR DESCRIPTION
This PR
- Simplifies the promise queue implementation (used to prevent concurrent `axe.run` calls, which doesn't work), so it's easier to understand.
- Moves some "axe" logic out of Result and into TestBrowser/AxePage, where it makes more sense (to me) for it to belong.