### PR TITLE
Add handling for known axe-core conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- [fix] Add handling for known axe-core conflicts [#103](https://github.com/chanzuckerberg/axe-storybook-testing/pull/103)
+- [fix] Add handling for known axe-core conflicts [#104](https://github.com/chanzuckerberg/axe-storybook-testing/pull/104)
 
 ## 8.2.1 (2024-10-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [fix] Add handling for known axe-core conflicts [#103](https://github.com/chanzuckerberg/axe-storybook-testing/pull/103)
+
 ## 8.2.1 (2024-10-21)
 
 - [fix] Simplify the promise queue implementation [#102](https://github.com/chanzuckerberg/axe-storybook-testing/pull/102)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ To use:
    npx playwright install
    ```
 
+You may also configure your script to run `storybook build --test` instead, and [configure storybook](https://storybook.js.org/docs/api/main-config/main-config-build) to disable irrelevant addons/features for testing.
+
 ## Options
 
 The command-line interface has the following options:

--- a/src/browser/AxePage.ts
+++ b/src/browser/AxePage.ts
@@ -59,6 +59,10 @@ export function analyze(
   });
 }
 
+/**
+ * (In Browser Context)
+ *
+ */
 function runAxe({
   config,
   context,
@@ -83,6 +87,7 @@ function runAxe({
       window.axe.configure(config);
     }
 
+    // API: https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#api-name-axerun
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore This function executes in a browser context.
     return window.axe.run(context || document, options);
@@ -106,6 +111,8 @@ export function getRunOptions(
 }
 
 /**
+ * (In Browser Context)
+ *
  * Add a promise queue so we can ensure only one promise runs at a time.
  *
  * Used to prevent concurrent runs of `axe.run`, which breaks (see https://github.com/dequelabs/axe-core/issues/1041).

--- a/src/browser/StorybookPage.ts
+++ b/src/browser/StorybookPage.ts
@@ -116,7 +116,7 @@ async function fetchStoriesFromWindow(): Promise<StorybookStory[]> {
 
 /**
  * Abuse Storybook's internal APIs to render a story without requiring a page reload (which would
- * be slow).
+ * be slow). Also set up globals for any values needed for the running tests.
  *
  * Doing so is brittle, and updates to Storybook could break this. The trade off is that we don't
  * have to figure out how to process stories with Webpack - Storybook handles that for us.
@@ -134,10 +134,19 @@ function emitSetCurrentStory(id: string) {
     );
   }
 
-  return new Promise((resolve) => {
-    // @ts-expect-error Access the protected "channel", so we can send stuff through it.
-    const channel = storybookPreview.channel;
+  // @ts-expect-error Access the protected "channel", so we can send stuff through it.
+  const channel = storybookPreview.channel;
 
+  // update global to disable known addons containing `axe-core`
+  channel.emit('updateGlobals', {
+    globals: {
+      a11y: {
+        manual: true,
+      },
+    },
+  });
+
+  return new Promise((resolve) => {
     channel.emit('setCurrentStory', {
       storyId: id,
       viewMode: 'story',


### PR DESCRIPTION
With [v8.5.0](https://github.com/storybookjs/storybook/releases/tag/v8.5.0), storybook includes some major updates to the library and provided addons, including significant updates to `@storybook/addon-a11y`. In the changes, they import `axe-core`, which will write content to `window.axe`. Our package does the same, so this will lead to runtime conflicts and test failures (e.g., `Axe is already running`).

Add an implementation that disables the addon when `axe-storybook` is run. This avoids the need to rebuild storybook just to run tests. This also sets up a method for any future overlapping plugins to be disabled as needed.

**NOTE**: We also include documentation [in the wiki](https://github.com/chanzuckerberg/axe-storybook-testing/wiki/FAQ-&-Troubleshooting) which would allow users of `axe-storybook-testing` v8.2.1 and older to work past this issue.

Re: #103 