### PR TITLE
Fix syntax of package.json using npm pkg fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [fix] update contents of package.json using `npm pkg fix`
+
 ## 8.2.2 (2025-01-26)
 
 - [fix] Add handling for known axe-core conflicts [#104](https://github.com/chanzuckerberg/axe-storybook-testing/pull/104)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [fix] update contents of package.json using `npm pkg fix`
+  [#105](https://github.com/chanzuckerberg/axe-storybook-testing/pull/105)
 
 ## 8.2.2 (2025-01-26)
 

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "homepage": "https://github.com/chanzuckerberg/axe-storybook-testing",
   "repository": {
     "type": "git",
-    "url": "https://github.com/chanzuckerberg/axe-storybook-testing.git"
+    "url": "git+https://github.com/chanzuckerberg/axe-storybook-testing.git"
   },
   "bin": {
-    "axe-storybook": "./bin/axe-storybook.js"
+    "axe-storybook": "bin/axe-storybook.js"
   },
   "main": "build/index.js",
   "files": [


### PR DESCRIPTION
Noticed on last release that there were some syntax warnings/errors that npm was automatically repairing. add these corrections to the actual file