### PR TITLE
Create promise queue on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [fix] update contents of package.json using `npm pkg fix`
   [#105](https://github.com/chanzuckerberg/axe-storybook-testing/pull/105)
 - [maintenance] Update all deps [#108](https://github.com/chanzuckerberg/axe-storybook-testing/pull/108)
+- [fix] Resolve an issue where the axe.run queue was not being setup properly, possibly caused by React 19.1.0 + Storybook 8.6.12 [#109](https://github.com/chanzuckerberg/axe-storybook-testing/pull/109)
 
 ## 8.2.2 (2025-01-26)
 


### PR DESCRIPTION
~~Re https://github.com/chanzuckerberg/axe-storybook-testing/issues/107 (at least my reproduction of it)~~ Resolves an issue I ran into where the axe.run queue can't be found when using React 19.1.0 and Storybook 8.6.12.

Not sure why this fixes it, but basically ensures that it's available before we try to use it.

@booc0mtaco 